### PR TITLE
chore: prevent yarn checksum failures

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -5,3 +5,5 @@ plugins:
     spec: "@yarnpkg/plugin-workspace-tools"
 
 yarnPath: .yarn/releases/yarn-3.1.1.cjs
+
+checksumBehavior: update

--- a/yarn.lock
+++ b/yarn.lock
@@ -6404,7 +6404,7 @@ __metadata:
   dependencies:
     bn.js: ^4.11.8
     ethereumjs-util: ^6.0.0
-  checksum: ae074be0bb012857ab5d3ae644d1163b908a48dd724b7d2567cfde309dc72222d460438f2411936a70dc949dc604ce1ef7118f7273bd525815579143c907e336
+  checksum: 03127d09960e5f8a44167463faf25b2894db2f746376dbb8195b789ed11762f93db9c574eaa7c498c400063508e9dfc1c80de2edf5f0e1406b25c87d860ff2f1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
yarn installs were failing due to a non-deterministic checksum in a deep dependency. this pr modifies yarn behavior to update its locally cached checksums instead of erroring on mismatch