### PR TITLE
fix: hh compilation works now

### DIFF
--- a/packages/contracts-bridge/hardhat.config.ts
+++ b/packages/contracts-bridge/hardhat.config.ts
@@ -1,5 +1,4 @@
 import "hardhat-gas-reporter";
-import "@typechain/hardhat";
 import "@nomiclabs/hardhat-etherscan";
 import "hardhat-packager";
 

--- a/packages/contracts-core/hardhat.config.ts
+++ b/packages/contracts-core/hardhat.config.ts
@@ -1,5 +1,4 @@
 import "hardhat-gas-reporter";
-import "@typechain/hardhat";
 import "@nomiclabs/hardhat-etherscan";
 import "hardhat-packager";
 

--- a/packages/contracts-router/hardhat.config.ts
+++ b/packages/contracts-router/hardhat.config.ts
@@ -1,5 +1,5 @@
 import "hardhat-gas-reporter";
-import "@typechain/hardhat";
+import "@nomiclabs/hardhat-etherscan";
 import "hardhat-packager";
 
 import * as dotenv from "dotenv";


### PR DESCRIPTION
Removes the `@typechain/hardhat` import from `hardhat.config.ts` files. This package was redundantly imported by `hardhat-packager`, causing a plugin clash which prevented compilation