### PR TITLE
chore: bump package versions to prep for publishing to npm

### DIFF
--- a/packages/contracts-bridge/package.json
+++ b/packages/contracts-bridge/package.json
@@ -24,7 +24,7 @@
   },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "version": "1.2.0",
+  "version": "1.0.0",
   "description": "A bridge using nomad",
   "scripts": {
     "bootstrap": "yarn clean && yarn build",

--- a/packages/contracts-core/package.json
+++ b/packages/contracts-core/package.json
@@ -21,7 +21,7 @@
     "typechain": "^5.0.0",
     "typescript": "^4.5.5"
   },
-  "version": "1.2.0",
+  "version": "1.0.0",
   "description": "Nomad contracts",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/contracts-router/package.json
+++ b/packages/contracts-router/package.json
@@ -23,7 +23,7 @@
   },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "version": "1.2.0",
+  "version": "1.0.0",
   "description": "The Nomad router, a reusable base for cross-chain applications",
   "scripts": {
     "bootstrap": "yarn clean && yarn build",

--- a/packages/multi-provider/package.json
+++ b/packages/multi-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nomad-xyz/multi-provider",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "A wrapper for multiple ethers.js providers, suitable for multi-chain applications",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/sdk-bridge/package.json
+++ b/packages/sdk-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nomad-xyz/sdk-bridge",
-  "version": "1.3.6",
+  "version": "1.0.0",
   "description": "Nomad bridge SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/sdk-govern/package.json
+++ b/packages/sdk-govern/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nomad-xyz/sdk-govern",
-  "version": "1.3.6",
+  "version": "1.0.0",
   "description": "Nomad governance SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nomad-xyz/sdk",
-  "version": "0.1.0",
+  "version": "2.0.0",
   "description": "Nomad SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
```
contracts-bridge - 1.0.0
contracts-core - 1.0.0
contracts-router - 1.0.0
sdk - 2.0.0
sdk-bridge - 1.0.0
sdk-govern - 1.0.0
multi-provider - 1.0.0
```