### PR TITLE
fix: keep configuration dependency up to date

### DIFF
--- a/packages/sdk-bridge/package.json
+++ b/packages/sdk-bridge/package.json
@@ -32,7 +32,7 @@
     "test": "ts-mocha ./tests/*.ts"
   },
   "dependencies": {
-    "@nomad-xyz/configuration": "0.1.0-rc.2",
+    "@nomad-xyz/configuration": "0.1.0-rc.3",
     "@nomad-xyz/sdk": "workspace:^",
     "ethers": "^5.4.6",
     "web3": "^1.6.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1156,7 +1156,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@nomad-xyz/sdk-bridge@workspace:packages/sdk-bridge"
   dependencies:
-    "@nomad-xyz/configuration": 0.1.0-rc.2
+    "@nomad-xyz/configuration": 0.1.0-rc.3
     "@nomad-xyz/sdk": "workspace:^"
     "@types/mocha": ^9.1.0
     "@types/node": ^16.9.1


### PR DESCRIPTION
sdk-bridge build and tests both fail without this change