### PR TITLE
fix: deployHeight uses a getter

### DIFF
--- a/packages/sdk-bridge/src/BridgeContracts.ts
+++ b/packages/sdk-bridge/src/BridgeContracts.ts
@@ -12,7 +12,6 @@ import * as config from '@nomad-xyz/configuration';
 
 export class BridgeContracts extends Contracts {
   readonly domain: string;
-  readonly deployHeight: number;
   protected conf: config.BridgeContracts;
 
   private providerOrSigner?: ethers.providers.Provider | ethers.Signer;
@@ -24,9 +23,12 @@ export class BridgeContracts extends Contracts {
   ) {
     super(domain, conf, providerOrSigner);
     this.domain = domain;
-    this.deployHeight = conf.deployHeight;
     this.conf = conf;
     this.providerOrSigner = providerOrSigner;
+  }
+
+  get deployHieght(): number {
+    return this.conf.deployHeight;
   }
 
   get bridgeRouter(): BridgeRouter {

--- a/packages/sdk-bridge/src/BridgeContracts.ts
+++ b/packages/sdk-bridge/src/BridgeContracts.ts
@@ -27,7 +27,7 @@ export class BridgeContracts extends Contracts {
     this.providerOrSigner = providerOrSigner;
   }
 
-  get deployHieght(): number {
+  get deployHeight(): number {
     return this.conf.deployHeight;
   }
 

--- a/packages/sdk/src/CoreContracts.ts
+++ b/packages/sdk/src/CoreContracts.ts
@@ -42,7 +42,7 @@ export class CoreContracts extends Contracts {
     return core.Replica__factory.connect(replica.proxy, this.providerOrSigner);
   }
 
-  get deployHieght(): number {
+  get deployHeight(): number {
     return this.conf.deployHeight;
   }
 

--- a/packages/sdk/src/CoreContracts.ts
+++ b/packages/sdk/src/CoreContracts.ts
@@ -17,7 +17,6 @@ export type Governor = LocalGovernor | RemoteGovernor;
 
 export class CoreContracts extends Contracts {
   readonly domain: string;
-  readonly deployHeight: number;
   protected conf: config.CoreContracts;
 
   private _governor?: Governor;
@@ -31,7 +30,6 @@ export class CoreContracts extends Contracts {
     super(domain, conf, providerOrSigner);
     this.providerOrSigner = providerOrSigner;
     this.domain = domain;
-    this.deployHeight = conf.deployHeight;
     this.conf = conf;
   }
 
@@ -42,6 +40,10 @@ export class CoreContracts extends Contracts {
     const replica = this.conf.replicas[domain];
     if (!replica) return;
     return core.Replica__factory.connect(replica.proxy, this.providerOrSigner);
+  }
+
+  get deployHieght(): number {
+    return this.conf.deployHeight;
   }
 
   get home(): core.Home {


### PR DESCRIPTION
rather than duplicating info in the constructor, we make an accessor for the deployheight