### PR TITLE
fix deploy: don't re-deploy or re-enroll

### DIFF
--- a/packages/new-deploy/src/bridge/BridgeContracts.ts
+++ b/packages/new-deploy/src/bridge/BridgeContracts.ts
@@ -360,6 +360,12 @@ export default class BridgeContracts extends AbstractBridgeDeploy<config.EvmBrid
 
     const enrollTxs = await Promise.all(
       customs.map(async (custom): Promise<ethers.PopulatedTransaction[]> => {
+        // don't re-deploy custom if already deployed
+        // TODO: break down each step, make idempotent
+        const existingCustom = this.data.customs?.find(potentialMatch => potentialMatch.token.id == custom.token.id && potentialMatch.token.domain == custom.token.domain);
+        if (existingCustom) return [];
+        console.log(`deploy ${custom.name} custom tokens on ${name}`);
+
         // deploy the controller
         const controller = await ubcFactory.deploy(this.overrides);
         await controller.deployTransaction.wait(this.confirmations);

--- a/packages/new-deploy/src/bridge/BridgeContracts.ts
+++ b/packages/new-deploy/src/bridge/BridgeContracts.ts
@@ -242,6 +242,9 @@ export default class BridgeContracts extends AbstractBridgeDeploy<config.EvmBrid
     if (!this.data.tokenRegistry)
       throw new Error('need token registry to deploy bridge');
 
+    // don't redeploy
+    if (this.data.bridgeRouter) return;
+
     const initData =
       contracts.BridgeRouter__factory.createInterface().encodeFunctionData(
         'initialize',

--- a/packages/new-deploy/src/core/CoreContracts.ts
+++ b/packages/new-deploy/src/core/CoreContracts.ts
@@ -537,10 +537,10 @@ export default class EvmCoreDeploy extends AbstractCoreDeploy<config.EvmCoreCont
     const remoteConfig = this.context.mustGetDomainConfig(remote);
 
     // don't re-enroll if already enrolled
-    const router = await this.governanceRouter.routers(
+    const enrolledRemote = await this.governanceRouter.routers(
         remoteConfig.domain
     );
-    if (!utils.equalIds(router, ethers.constants.AddressZero)) return [];
+    if (!utils.equalIds(enrolledRemote, ethers.constants.AddressZero)) return [];
 
     // Check that this key has permissions to set this
     const owner = await this.governanceRouter.governor();

--- a/packages/new-deploy/src/core/CoreContracts.ts
+++ b/packages/new-deploy/src/core/CoreContracts.ts
@@ -536,6 +536,12 @@ export default class EvmCoreDeploy extends AbstractCoreDeploy<config.EvmCoreCont
     const remoteCore = this.context.mustGetCore(remote);
     const remoteConfig = this.context.mustGetDomainConfig(remote);
 
+    // don't re-enroll if already enrolled
+    const router = await this.governanceRouter.routers(
+        remoteConfig.domain
+    );
+    if (!utils.equalIds(router, ethers.constants.AddressZero)) return [];
+
     // Check that this key has permissions to set this
     const owner = await this.governanceRouter.governor();
     const deployer = ethers.utils.getAddress(await this.deployer.getAddress());

--- a/packages/new-deploy/src/core/CoreContracts.ts
+++ b/packages/new-deploy/src/core/CoreContracts.ts
@@ -613,6 +613,7 @@ export default class EvmCoreDeploy extends AbstractCoreDeploy<config.EvmCoreCont
   /// governorship
   async appointGovernor(): Promise<void> {
     const governor = this.context.data.protocol.governor;
+    const localDomain = this.context.resolveDomain(this.domain);
 
     // Check that the deployer key has permissions to transfer governor
     const owner = await this.governanceRouter.governor();
@@ -620,6 +621,8 @@ export default class EvmCoreDeploy extends AbstractCoreDeploy<config.EvmCoreCont
 
     // If the deployer key DOES have permissions to transfer governor,
     if (utils.equalIds(owner, deployer)) {
+      // if the deployer key is the rightful governor, don't attempt to transfer gov
+      if (utils.equalIds(owner, governor.id) && governor.domain == localDomain) return;
       // submit transaction to transfer governor
       const tx = await this.governanceRouter.transferGovernor(
         governor.domain,

--- a/packages/new-deploy/src/core/CoreContracts.ts
+++ b/packages/new-deploy/src/core/CoreContracts.ts
@@ -491,6 +491,8 @@ export default class EvmCoreDeploy extends AbstractCoreDeploy<config.EvmCoreCont
       (_, idx) => !enrollmentStatuses[idx],
     );
 
+    if (watchersToEnroll.length == 0) return [];
+
     // Check that this key has permissions to set this
     const owner = await this.xAppConnectionManager.owner();
     const deployer = ethers.utils.getAddress(await this.deployer.getAddress());

--- a/packages/new-deploy/src/core/CoreContracts.ts
+++ b/packages/new-deploy/src/core/CoreContracts.ts
@@ -366,11 +366,12 @@ export default class EvmCoreDeploy extends AbstractCoreDeploy<config.EvmCoreCont
   async deployUnenrolledReplica(homeDomain: string | number): Promise<void> {
     const local = this.context.resolveDomainName(this.domain);
     const home = this.context.resolveDomainName(homeDomain);
-
-    const homeCore = this.context.mustGetCore(local);
-
     const localConfig = this.context.mustGetDomainConfig(local);
     const homeConfig = this.context.mustGetDomainConfig(home);
+    const homeCore = this.context.mustGetCore(local);
+
+    // don't redeploy existing replica
+    if (this.data.replicas && this.data.replicas[home]) return;
 
     const root = await homeCore.home.committedRoot();
 


### PR DESCRIPTION
- don't re-deploy existing replica proxies for already-deployed chains
- prevent multiple replica beacons & implementations from being deployed due to concurrency
- don't re-deploy bridge router
- don't re-deploy custom tokens
- don't re-appoint governor if deployer key is rightful governor
- don't re-enroll bridge router
- don't re-enroll governance router
- skip further checks if no watchers to enroll