### PR TITLE
fix: convert verification map to object before logging to output file

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "contracts-core": "yarn workspace @nomad-xyz/contracts-core",
     "contracts-router": "yarn workspace @nomad-xyz/contracts-router",
     "deploy": "yarn workspace @nomad-xyz/deploy",
+    "new-deploy": "yarn workspace @nomad-xyz/new-deploy",
     "lint": "yarn workspaces foreach -Apv --exclude @nomad-xyz/deploy  --exclude @nomad-xyz/local-environment run lint",
     "local-environment": "yarn workspace @nomad-xyz/local-environment",
     "monitor": "yarn workspace @nomad-xyz/monitor",

--- a/packages/new-deploy/scripts/deploy.ts
+++ b/packages/new-deploy/scripts/deploy.ts
@@ -34,7 +34,7 @@ async function run() {
     const outputDir = "./output";
     fs.mkdirSync(outputDir, { recursive: true });
     fs.writeFileSync(`${outputDir}/config.json`, JSON.stringify(deployContext.data, null, 4));
-    fs.writeFileSync(`${outputDir}/verification.json`, JSON.stringify(deployContext.verification, null, 4));
+    fs.writeFileSync(`${outputDir}/verification.json`, JSON.stringify(Object.fromEntries(deployContext.verification), null, 4));
     fs.writeFileSync(`${outputDir}/governanceTransactions.json`, JSON.stringify(governanceTransactions, null, 4));
     console.log(`DONE!`);
 }


### PR DESCRIPTION
Closes #116 

@anna-carroll Reproduced the issue above following these steps
- removing the entire kovan object from the core object in `new-deploy/development/config.json`
- running `yarn new-deploy deploy`

I confirmed that `pushVerification` is working as expected. The reason the `verification.json` output file was empty is due to the way that `JSON.stringify` works with `Map`, the verification map needed to be converted to an object first otherwise it will appear empty.

Also added a helper script to run deploys from the monorepo root.
