### PR TITLE
fix: better iteration in asNomadContext

### DIFF
--- a/packages/new-deploy/package.json
+++ b/packages/new-deploy/package.json
@@ -11,6 +11,7 @@
     "ethers": "^5.5.1",
     "hardhat-packager": "^1.2.1",
     "prettier": "^2.3.1",
+    "ts-mocha": "^9.0.2",
     "ts-node": "^10.1.0",
     "typechain": "^5.0.0",
     "typescript": "^4.5.5"
@@ -25,6 +26,8 @@
     "check": "tsc --noEmit",
     "prettier": "prettier --write ./src",
     "lint": "eslint --fix ./src",
+    "test": "ts-mocha ./tests/*.ts",
+    "coverage": "nyc --reporter=html ts-mocha ./tests/*.ts",
     "deploy": "ts-node scripts/deploy.ts config/development/config.json config/development/overrides.json",
     "check-deploy": "ts-node scripts/check.ts config/development/config.json"
   },

--- a/packages/new-deploy/scripts/check.ts
+++ b/packages/new-deploy/scripts/check.ts
@@ -1,11 +1,11 @@
-import DeployContext from '../src/DeployContext';
+import { DeployContext } from '../src/DeployContext';
 import * as config from '@nomad-xyz/configuration';
-import {getConfig} from "./utils";
+import { getConfig } from "./utils";
 
 run();
 
 async function run() {
-// instantiate deploy context
+    // instantiate deploy context
     const DEPLOY_CONFIG: config.NomadConfig = getConfig();
     const deployContext = new DeployContext(DEPLOY_CONFIG);
 

--- a/packages/new-deploy/src/Contracts.ts
+++ b/packages/new-deploy/src/Contracts.ts
@@ -1,4 +1,4 @@
-import DeployContext from './DeployContext';
+import { DeployContext } from './DeployContext';
 
 export default abstract class Contracts<T> {
   protected _data: Partial<T>;

--- a/packages/new-deploy/src/DeployContext.ts
+++ b/packages/new-deploy/src/DeployContext.ts
@@ -14,7 +14,7 @@ export interface Verification {
   constructorArguments?: ReadonlyArray<unknown>;
 }
 
-export default class DeployContext extends MultiProvider<config.Domain> {
+export class DeployContext extends MultiProvider<config.Domain> {
   overrides: Map<string, ethers.Overrides>;
   protected _data: config.NomadConfig;
   protected _verification: Map<string, Array<Verification>>;

--- a/packages/new-deploy/src/DeployContext.ts
+++ b/packages/new-deploy/src/DeployContext.ts
@@ -37,8 +37,8 @@ export default class DeployContext extends MultiProvider<config.Domain> {
   get asNomadContext(): NomadContext {
     const ctx = new NomadContext(this.data);
 
-    for (const key in this.domains.keys()) {
-      ctx.registerProvider(key, this.mustGetProvider(key));
+    for (const [domain, provider] of this.providers.entries()) {
+      ctx.registerProvider(domain, provider);
     }
     return ctx;
   }

--- a/packages/new-deploy/src/bridge/BridgeContracts.ts
+++ b/packages/new-deploy/src/bridge/BridgeContracts.ts
@@ -10,7 +10,7 @@ import { utils } from '@nomad-xyz/multi-provider';
 import * as config from '@nomad-xyz/configuration';
 
 import Contracts from '../Contracts';
-import DeployContext from '../DeployContext';
+import { DeployContext } from '../DeployContext';
 import { log, assertBeaconProxy } from '../utils';
 import { expect } from 'chai';
 import { Call, CallBatch } from '@nomad-xyz/sdk-govern';

--- a/packages/new-deploy/src/core/CoreContracts.ts
+++ b/packages/new-deploy/src/core/CoreContracts.ts
@@ -13,7 +13,7 @@ import { ethers } from 'ethers';
 import { Call, CallBatch } from '@nomad-xyz/sdk-govern';
 
 import Contracts from '../Contracts';
-import DeployContext from '../DeployContext';
+import { DeployContext } from '../DeployContext';
 
 import { expect } from 'chai';
 import { log, assertBeaconProxy } from '../utils';

--- a/packages/new-deploy/src/index.ts
+++ b/packages/new-deploy/src/index.ts
@@ -1,5 +1,6 @@
 export * from './Contracts';
 export * from './bridge';
 export * from './core';
-export * from './DeployContext';
 export * from './utils';
+
+export { DeployContext, Verification } from './DeployContext';

--- a/packages/new-deploy/tests/index.test.ts
+++ b/packages/new-deploy/tests/index.test.ts
@@ -1,0 +1,20 @@
+import { describe, it } from 'mocha';
+import { expect } from 'chai';
+
+import * as config from '@nomad-xyz/configuration';
+
+import * as deploy from '../src';
+
+describe('deploy', async () => {
+  describe('DeployContext', () => {
+    it('converts itself to a NomadContext and registers providers', async () => {
+      const conf = config.getBuiltin('development');
+
+      const ctx = new deploy.DeployContext(conf);
+      ctx.registerRpcProvider('rinkeby', 'http://dummyurl.com');
+
+      const nomadCtx = ctx.asNomadContext;
+      expect(nomadCtx.getConnection('rinkeby')).to.not.be.undefined;
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1438,6 +1438,7 @@ __metadata:
     ethers: ^5.5.1
     hardhat-packager: ^1.2.1
     prettier: ^2.3.1
+    ts-mocha: ^9.0.2
     ts-node: ^10.1.0
     typechain: ^5.0.0
     typescript: ^4.5.5


### PR DESCRIPTION
`DeployContext.asNomadContext` appears to not be registering providers properly in the returned context. This PR simplifies registration logic in an attempt to fix it

## Solution

Iterate over entries instead of keys to avoid type confusion

## PR Checklist

- [x] Added Tests
- [ ] Updated Documentation
- [ ] Updated CHANGELOG.md for the appropriate package
