### PR TITLE
refactor: un-complicate sdk connection logic

### DIFF
--- a/packages/multi-provider/changelog.md
+++ b/packages/multi-provider/changelog.md
@@ -1,0 +1,5 @@
+# Changelog
+
+### Unreleased
+
+- refactor: additional functionality on the `Contracts` type

--- a/packages/multi-provider/package.json
+++ b/packages/multi-provider/package.json
@@ -26,7 +26,7 @@
     "prettier": "prettier --write ./src ./tests",
     "lint": "eslint --fix ./src ./tests",
     "lint:fix": "eslint --fix ./src ./tests",
-    "test": "ts-mocha ./tests/*.ts",
+    "test": "yarn build && ts-mocha ./tests/*.ts",
     "coverage": "nyc --reporter=html ts-mocha ./tests/*.ts"
   },
   "dependencies": {

--- a/packages/multi-provider/src/contracts.ts
+++ b/packages/multi-provider/src/contracts.ts
@@ -3,7 +3,10 @@ import { Domain } from './domains';
 import { MultiProvider } from './provider';
 
 /**
- * Abstract class for managing collections of contracts
+ * Abstract class for managing collections of contracts.
+ *
+ * This class holds a context (based on the {@link MultiProvider}) and
+ * retrieves connections for contracts from it.
  */
 export abstract class Contracts<U extends Domain, T extends MultiProvider<U>> {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/multi-provider/src/contracts.ts
+++ b/packages/multi-provider/src/contracts.ts
@@ -1,19 +1,32 @@
 import { ethers } from 'ethers';
+import { Domain } from './domains';
+import { MultiProvider } from './provider';
 
 /**
  * Abstract class for managing collections of contracts
  */
-export abstract class Contracts {
+export abstract class Contracts<U extends Domain, T extends MultiProvider<U>> {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   readonly args: any[];
+
+  readonly domain: string;
+  protected context: T;
 
   /**
    *
    * @param args Any arguments for the Contracts object.
    */
-  constructor(...args: any[]) {
+  constructor(context: T, domain: string, ...args: any[]) {
+    this.context = context;
     this.args = args;
+    this.domain = domain;
   }
 
-  abstract connect(signer: ethers.Signer): void;
+  get connection(): ethers.Signer | ethers.providers.Provider | undefined {
+    return this.context.getConnection(this.domain);
+  }
+
+  get domainNumber(): number {
+    return this.context.resolveDomain(this.domain);
+  }
 }

--- a/packages/multi-provider/src/utils.ts
+++ b/packages/multi-provider/src/utils.ts
@@ -144,6 +144,9 @@ export class UnreachableError extends Error {
   }
 }
 
+/**
+ * An error containing a multi-provider-based context
+ */
 export abstract class WithContext<
   D extends Domain,
   T extends MultiProvider<D>,
@@ -156,6 +159,9 @@ export abstract class WithContext<
   }
 }
 
+/**
+ * Thrown when attempting to access a domain not registered on the context
+ */
 export class UnknownDomainError<
   D extends Domain,
   T extends MultiProvider<D>,
@@ -163,12 +169,22 @@ export class UnknownDomainError<
   domain: string | number;
 
   constructor(provider: T, domain: string | number) {
-    super(provider, `Attempted to access an unknown domain: ${domain}`);
+    super(
+      provider,
+      `
+      Attempted to access an unknown domain: ${domain}.
+      Hint: have you called \`context.registerDomain(...)\` yet?
+      `,
+    );
     this.name = 'UnknownDomainError';
     this.domain = domain;
   }
 }
 
+/**
+ * Thrown when attempting to access contract data on a domain with no
+ * registered provider
+ */
 export class NoProviderError<
   D extends Domain,
   T extends MultiProvider<D>,
@@ -183,7 +199,11 @@ export class NoProviderError<
 
     super(
       provider,
-      `Missing provider for domain: ${domainNumber} : ${domainName}`,
+      `
+      Missing provider for domain: ${domainNumber} : ${domainName}.
+      Hint: Have you called \`context.registerProvider(${domain}, provider)\`
+      yet?
+      `,
     );
     this.name = 'NoProviderError';
     this.domain = domain;

--- a/packages/multi-provider/src/utils.ts
+++ b/packages/multi-provider/src/utils.ts
@@ -171,10 +171,7 @@ export class UnknownDomainError<
   constructor(provider: T, domain: string | number) {
     super(
       provider,
-      `
-      Attempted to access an unknown domain: ${domain}.
-      Hint: have you called \`context.registerDomain(...)\` yet?
-      `,
+      `Attempted to access an unknown domain: ${domain}.\nHint: have you called \`context.registerDomain(...)\` yet?`,
     );
     this.name = 'UnknownDomainError';
     this.domain = domain;
@@ -199,11 +196,7 @@ export class NoProviderError<
 
     super(
       provider,
-      `
-      Missing provider for domain: ${domainNumber} : ${domainName}.
-      Hint: Have you called \`context.registerProvider(${domain}, provider)\`
-      yet?
-      `,
+      `Missing provider for domain: ${domainNumber} : ${domainName}.\nHint: Have you called \`context.registerProvider(${domain}, provider)\` yet?`,
     );
     this.name = 'NoProviderError';
     this.domain = domain;

--- a/packages/multi-provider/tests/index.test.ts
+++ b/packages/multi-provider/tests/index.test.ts
@@ -209,22 +209,21 @@ describe('multi-provider', async () => {
   });
 
   it('instantiates Contracts class with appropriate args', () => {
-    class SomeContracts extends Contracts {
-      readonly domain: number;
+    class SomeContracts extends Contracts<Domain, MultiProvider<Domain>> {
       readonly name: string;
 
-      constructor(domain: number, name: string) {
-        super(domain, name);
-        this.domain = domain;
-        this.name = name;
-      }
-      connect(): void {
-        return;
+      constructor(name: string, domain: number) {
+        super(new MultiProvider(), name, domain);
+        this.context.registerDomain({
+          name: 'someChain',
+          domain: 2000,
+        });
       }
     }
-    const newContracts = new SomeContracts(2000, 'someChain');
+    const newContracts = new SomeContracts('someChain', 2000);
+    expect(newContracts.domain).to.equal('someChain');
+    expect(newContracts.domainNumber).to.equal(2000);
     expect(newContracts.args[0]).to.equal(2000);
-    expect(newContracts.args[1]).to.equal('someChain');
   });
 
   it.skip('TODO: resolveDomainName errors');

--- a/packages/sdk-bridge/changelog.md
+++ b/packages/sdk-bridge/changelog.md
@@ -1,5 +1,10 @@
-# Changelog 
+# Changelog
+
+### Unreleased
+
+- refactor: simpler connection logic (deleting `reconnect`)
+- refactor: improved generics in types using contexts
 
 ### 1.0.0-rc.4
 
-- feature: Added `BridgeContracts.deployHeight` getter 
+- feature: Added `BridgeContracts.deployHeight` getter

--- a/packages/sdk-bridge/package.json
+++ b/packages/sdk-bridge/package.json
@@ -29,7 +29,7 @@
     "lint": "eslint --fix ./src ./tests",
     "lint:fix": "eslint --fix ./src ./tests",
     "prettier": "prettier --write ./src ./tests",
-    "test": "ts-mocha ./tests/*.ts",
+    "test": "yarn build && ts-mocha ./tests/*.ts",
     "coverage": "nyc --reporter=html ts-mocha ./tests/*.ts"
   },
   "dependencies": {

--- a/packages/sdk-bridge/package.json
+++ b/packages/sdk-bridge/package.json
@@ -41,6 +41,7 @@
   },
   "devDependencies": {
     "@types/chai": "^4.2.21",
+    "@types/mocha": "^9.1.0",
     "@types/node": "^16.9.1",
     "@typescript-eslint/eslint-plugin": "^4.33.0",
     "@typescript-eslint/parser": "^4.33.0",

--- a/packages/sdk-bridge/src/BridgeContext.ts
+++ b/packages/sdk-bridge/src/BridgeContext.ts
@@ -25,7 +25,8 @@ export class BridgeContext extends NomadContext {
 
     this.bridges = new Map();
     const bridges = this.conf.networks.map(
-      (network) => new BridgeContracts(network, this.conf.bridge[network]),
+      (network) =>
+        new BridgeContracts(this, network, this.conf.bridge[network]),
     );
 
     bridges.forEach((bridge) => {
@@ -45,25 +46,6 @@ export class BridgeContext extends NomadContext {
     }
 
     return bridge;
-  }
-
-  /**
-   * Ensure that the contracts on a given domain are connected to the
-   * currently-registered signer or provider.
-   *
-   * @param domain the domain to reconnect
-   */
-  protected reconnect(nameOrDomain: string | number): void {
-    const domain = this.resolveDomainName(nameOrDomain);
-    super.reconnect(domain);
-    const connection = this.getConnection(domain);
-    if (!connection) {
-      throw new Error(`Reconnect failed: no connection for ${domain}`);
-    }
-    const bridge = this.bridges.get(domain);
-    if (bridge) {
-      bridge.connect(connection);
-    }
   }
 
   /**

--- a/packages/sdk-bridge/src/BridgeContracts.ts
+++ b/packages/sdk-bridge/src/BridgeContracts.ts
@@ -1,5 +1,4 @@
-import { ethers } from 'ethers';
-import { Contracts } from '@nomad-xyz/multi-provider';
+import { Contracts, NoProviderError } from '@nomad-xyz/multi-provider';
 import {
   BridgeRouter,
   TokenRegistry,
@@ -9,22 +8,18 @@ import {
   ETHHelper__factory,
 } from '@nomad-xyz/contracts-bridge';
 import * as config from '@nomad-xyz/configuration';
+import { BridgeContext } from './BridgeContext';
 
-export class BridgeContracts extends Contracts {
-  readonly domain: string;
+export class BridgeContracts extends Contracts<config.Domain, BridgeContext> {
   protected conf: config.BridgeContracts;
 
-  private providerOrSigner?: ethers.providers.Provider | ethers.Signer;
-
   constructor(
+    context: BridgeContext,
     domain: string,
     conf: config.BridgeContracts,
-    providerOrSigner?: ethers.providers.Provider | ethers.Signer,
   ) {
-    super(domain, conf, providerOrSigner);
-    this.domain = domain;
+    super(context, domain, conf);
     this.conf = conf;
-    this.providerOrSigner = providerOrSigner;
   }
 
   get deployHeight(): number {
@@ -32,37 +27,24 @@ export class BridgeContracts extends Contracts {
   }
 
   get bridgeRouter(): BridgeRouter {
-    if (!this.providerOrSigner) {
-      throw new Error('No provider or signer. Call `connect` first.');
-    }
+    if (!this.connection) throw new NoProviderError(this.context, this.domain);
     return BridgeRouter__factory.connect(
       this.conf.bridgeRouter.proxy,
-      this.providerOrSigner,
+      this.connection,
     );
   }
 
   get tokenRegistry(): TokenRegistry {
-    if (!this.providerOrSigner) {
-      throw new Error('No provider or signer. Call `connect` first.');
-    }
+    if (!this.connection) throw new NoProviderError(this.context, this.domain);
     return TokenRegistry__factory.connect(
       this.conf.tokenRegistry.proxy,
-      this.providerOrSigner,
+      this.connection,
     );
   }
 
   get ethHelper(): ETHHelper | undefined {
-    if (!this.providerOrSigner) {
-      throw new Error('No provider or signer. Call `connect` first.');
-    }
+    if (!this.connection) throw new NoProviderError(this.context, this.domain);
     if (!this.conf.ethHelper) return;
-    return ETHHelper__factory.connect(
-      this.conf.ethHelper,
-      this.providerOrSigner,
-    );
-  }
-
-  connect(providerOrSigner: ethers.providers.Provider | ethers.Signer): void {
-    this.providerOrSigner = providerOrSigner;
+    return ETHHelper__factory.connect(this.conf.ethHelper, this.connection);
   }
 }

--- a/packages/sdk-bridge/src/BridgeContracts.ts
+++ b/packages/sdk-bridge/src/BridgeContracts.ts
@@ -26,6 +26,14 @@ export class BridgeContracts extends Contracts<config.Domain, BridgeContext> {
     return this.conf.deployHeight;
   }
 
+  /**
+   * Get the BridgeRouter associated with this bridge.
+   *
+   * WARNING: do not hold references to this contract, as it will not be
+   * reconnected in the event the chain connection changes.
+   *
+   * @throws if there is no connection for this network
+   */
   get bridgeRouter(): BridgeRouter {
     if (!this.connection) throw new NoProviderError(this.context, this.domain);
     return BridgeRouter__factory.connect(
@@ -34,6 +42,14 @@ export class BridgeContracts extends Contracts<config.Domain, BridgeContext> {
     );
   }
 
+  /**
+   * Get the TokenRegistry associated with this bridge.
+   *
+   * WARNING: do not hold references to this contract, as it will not be
+   * reconnected in the event the chain connection changes.
+   *
+   * @throws if there is no connection for this network
+   */
   get tokenRegistry(): TokenRegistry {
     if (!this.connection) throw new NoProviderError(this.context, this.domain);
     return TokenRegistry__factory.connect(
@@ -42,6 +58,14 @@ export class BridgeContracts extends Contracts<config.Domain, BridgeContext> {
     );
   }
 
+  /**
+   * Get the EthHelper associated with this bridge (if any).
+   *
+   * WARNING: do not hold references to this contract, as it will not be
+   * reconnected in the event the chain connection changes.
+   *
+   * @throws if there is no connection for this network
+   */
   get ethHelper(): ETHHelper | undefined {
     if (!this.connection) throw new NoProviderError(this.context, this.domain);
     if (!this.conf.ethHelper) return;

--- a/packages/sdk-govern/package.json
+++ b/packages/sdk-govern/package.json
@@ -43,6 +43,7 @@
   },
   "devDependencies": {
     "@types/chai": "^4.2.21",
+    "@types/mocha": "^9.1.0",
     "@types/node": "^16.9.1",
     "@typescript-eslint/eslint-plugin": "^4.33.0",
     "@typescript-eslint/parser": "^4.33.0",

--- a/packages/sdk-govern/package.json
+++ b/packages/sdk-govern/package.json
@@ -29,7 +29,7 @@
     "lint": "eslint --fix ./src ./tests",
     "lint:fix": "eslint --fix ./src ./tests",
     "prettier": "prettier --write ./src ./tests",
-    "test": "ts-mocha ./tests/*.ts",
+    "test": "yarn build && ts-mocha ./tests/*.ts",
     "coverage": "nyc --reporter=html ts-mocha ./tests/*.ts"
   },
   "dependencies": {

--- a/packages/sdk-govern/src/GovernanceMessage.ts
+++ b/packages/sdk-govern/src/GovernanceMessage.ts
@@ -64,8 +64,8 @@ export type AnyGovernanceMessage = TransferGovernorMessage | BatchMessage;
  * functionality.
  */
 class GovernanceMessage extends NomadMessage<NomadContext> {
-  readonly fromCore: CoreContracts;
-  readonly toCore: CoreContracts;
+  readonly fromCore: CoreContracts<NomadContext>;
+  readonly toCore: CoreContracts<NomadContext>;
 
   /**
    * @hideconstructor

--- a/packages/sdk-govern/src/index.ts
+++ b/packages/sdk-govern/src/index.ts
@@ -2,6 +2,7 @@ import { ethers } from 'ethers';
 import { NomadContext, CoreContracts } from '@nomad-xyz/sdk';
 
 import * as utils from './utils';
+import { UnreachableError } from '@nomad-xyz/multi-provider';
 export { parseAction, Action } from './GovernanceMessage';
 
 export type Address = string;
@@ -29,7 +30,7 @@ export interface CallBatchContents {
 export class CallBatch {
   readonly local: Readonly<NormalizedCall>[];
   readonly remote: Map<number, Readonly<NormalizedCall>[]>;
-  private governorCore: CoreContracts;
+  private governorCore: CoreContracts<NomadContext>;
   private context: NomadContext;
   private built?: ethers.PopulatedTransaction;
 
@@ -150,6 +151,7 @@ export class CallBatch {
         domains,
         remoteCalls,
       );
+    if (!this.built) throw new UnreachableError('built is undefined');
     return this.built;
   }
 

--- a/packages/sdk/changelog.md
+++ b/packages/sdk/changelog.md
@@ -1,5 +1,10 @@
-# Changelog 
+# Changelog
+
+### Unreleased
+
+- refactor: simpler connection logic (deleting `reconnect`)
+- refactor: improved generics in types using contexts
 
 ### 2.0.0-rc.4
 
-- feature: Added `CoreContracts.deployHeight` getter 
+- feature: Added `CoreContracts.deployHeight` getter

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -28,7 +28,7 @@
     "prettier": "prettier --write ./src ./tests",
     "lint": "eslint --fix ./src ./tests",
     "lint:fix": "eslint --fix ./src ./tests",
-    "test": "ts-mocha ./tests/*.ts",
+    "test": "yarn build && ts-mocha ./tests/*.ts",
     "coverage": "nyc --reporter=html ts-mocha ./tests/*.ts"
   },
   "dependencies": {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -40,6 +40,7 @@
   "devDependencies": {
     "@nomad-xyz/local-environment": "workspace:^",
     "@types/chai": "^4.2.21",
+    "@types/mocha": "^9.1.0",
     "@types/node": "^16.9.1",
     "@typescript-eslint/eslint-plugin": "^4.33.0",
     "@typescript-eslint/parser": "^4.33.0",

--- a/packages/sdk/tests/index.test.ts
+++ b/packages/sdk/tests/index.test.ts
@@ -3,6 +3,7 @@ import { expect } from 'chai';
 import { constants, getDefaultProvider, VoidSigner } from 'ethers';
 import { NomadContext, CoreContracts } from '@nomad-xyz/sdk';
 import * as config from '@nomad-xyz/configuration';
+import { NoProviderError } from '@nomad-xyz/multi-provider';
 // import { LocalGovernor, RemoteGovernor } from '../dist/CoreContracts';
 
 const ENVIRONMENTS = ['test', 'development', 'staging', 'production'];
@@ -96,20 +97,27 @@ describe('sdk', async () => {
 
   describe('CoreContracts', () => {
     let conf: config.NomadConfig;
-    let coreContracts: CoreContracts;
+    let coreContracts: CoreContracts<NomadContext>;
+    let context: NomadContext;
 
     before('instantiates contracts', () => {
       conf = config.getBuiltin('development');
-      coreContracts = new CoreContracts('rinkeby', conf.core['rinkeby']);
+      context = new NomadContext(conf);
+      coreContracts = new CoreContracts(
+        context,
+        'rinkeby',
+        conf.core['rinkeby'],
+      );
     });
-    it('errors if no provider or signer', () => {
-      const errMsg = 'No provider or signer. Call `connect` first.';
 
+    it('errors if no provider or signer', () => {
       // TODO: allow name or domain?
-      expect(() => coreContracts.getReplica('kovan')).to.throw(errMsg);
-      expect(() => coreContracts.home).to.throw(errMsg);
-      expect(() => coreContracts.governanceRouter).to.throw(errMsg);
-      expect(() => coreContracts.xAppConnectionManager).to.throw(errMsg);
+      expect(() => coreContracts.getReplica('kovan')).to.throw(NoProviderError);
+      expect(() => coreContracts.home).to.throw(NoProviderError);
+      expect(() => coreContracts.governanceRouter).to.throw(NoProviderError);
+      expect(() => coreContracts.xAppConnectionManager).to.throw(
+        NoProviderError,
+      );
     });
 
     it.skip('gets governor and stores in class state', async () => {

--- a/packages/sdk/tests/index.test.ts
+++ b/packages/sdk/tests/index.test.ts
@@ -4,7 +4,6 @@ import { constants, getDefaultProvider, VoidSigner } from 'ethers';
 import { NomadContext, CoreContracts } from '@nomad-xyz/sdk';
 import * as config from '@nomad-xyz/configuration';
 import { NoProviderError } from '@nomad-xyz/multi-provider';
-// import { LocalGovernor, RemoteGovernor } from '../dist/CoreContracts';
 
 const ENVIRONMENTS = ['test', 'development', 'staging', 'production'];
 
@@ -111,7 +110,6 @@ describe('sdk', async () => {
     });
 
     it('errors if no provider or signer', () => {
-      // TODO: allow name or domain?
       expect(() => coreContracts.getReplica('kovan')).to.throw(NoProviderError);
       expect(() => coreContracts.home).to.throw(NoProviderError);
       expect(() => coreContracts.governanceRouter).to.throw(NoProviderError);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1452,6 +1452,7 @@ __metadata:
     "@nomad-xyz/contracts-bridge": "workspace:^"
     "@nomad-xyz/sdk": "workspace:^"
     "@types/chai": ^4.2.21
+    "@types/mocha": ^9.1.0
     "@types/node": ^16.9.1
     "@typescript-eslint/eslint-plugin": ^4.33.0
     "@typescript-eslint/parser": ^4.33.0
@@ -1479,6 +1480,7 @@ __metadata:
     "@nomad-xyz/configuration": ^0.1.0-rc.7
     "@nomad-xyz/sdk": "workspace:^"
     "@types/chai": ^4.2.21
+    "@types/mocha": ^9.1.0
     "@types/node": ^16.9.1
     "@typescript-eslint/eslint-plugin": ^4.33.0
     "@typescript-eslint/parser": ^4.33.0
@@ -1505,6 +1507,7 @@ __metadata:
     "@nomad-xyz/local-environment": "workspace:^"
     "@nomad-xyz/multi-provider": "workspace:^"
     "@types/chai": ^4.2.21
+    "@types/mocha": ^9.1.0
     "@types/node": ^16.9.1
     "@typescript-eslint/eslint-plugin": ^4.33.0
     "@typescript-eslint/parser": ^4.33.0
@@ -2206,6 +2209,13 @@ __metadata:
   dependencies:
     "@types/node": "*"
   checksum: 21e6681ee18cee6314dbe0f57ada48981912b76de8266f438ba2573770d60aaa8dd376baad3f20e2346696a7cca84b0aadd1737222341553a0091831a46e6ad1
+  languageName: node
+  linkType: hard
+
+"@types/mocha@npm:^9.1.0":
+  version: 9.1.0
+  resolution: "@types/mocha@npm:9.1.0"
+  checksum: 21e1000dafcfe387c6812be41c44a47b48c27a74d5a70c3d5ef1bb5c88eadadfc74dba06e93f160e7248c8a57b3977b590f82504c801c9927816ecd4668023c0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
remove complicated and brittle reconnection logic in the sdks

## Solution

- SDK packages now follow the same pattern as the new deploy package
- Contract object now pull a connection from the context on demand, rather than caching a reference to it

## PR Checklist

- [x] Added Tests
- [x] Updated Documentation
- [x] Updated CHANGELOG.md for the appropriate package
