### PR TITLE
bug: get replica name or domain

### DIFF
--- a/packages/sdk/changelog.md
+++ b/packages/sdk/changelog.md
@@ -4,6 +4,7 @@
 
 - refactor: simpler connection logic (deleting `reconnect`)
 - refactor: improved generics in types using contexts
+- bug: getReplica only accepts domain number
 
 ### 2.0.0-rc.4
 

--- a/packages/sdk/src/CoreContracts.ts
+++ b/packages/sdk/src/CoreContracts.ts
@@ -29,6 +29,12 @@ export class CoreContracts<T extends NomadContext> extends Contracts<
     this.conf = conf;
   }
 
+  /**
+   * Resolves Replica with given domain
+   *
+   * @param nameOrDomain The name or domain ID of the Replica
+   * @returns An interface for the Replica, undefined if not found
+   */
   getReplica(nameOrDomain: string | number): core.Replica | undefined {
     const domain = this.context.resolveDomain(nameOrDomain);
     if (!this.connection) throw new NoProviderError(this.context, domain);

--- a/packages/sdk/src/CoreContracts.ts
+++ b/packages/sdk/src/CoreContracts.ts
@@ -36,7 +36,7 @@ export class CoreContracts<T extends NomadContext> extends Contracts<
    * @returns An interface for the Replica, undefined if not found
    */
   getReplica(nameOrDomain: string | number): core.Replica | undefined {
-    const domain = this.context.resolveDomain(nameOrDomain);
+    const domain = this.context.resolveDomainName(nameOrDomain);
     if (!this.connection) throw new NoProviderError(this.context, domain);
     const replica = this.conf.replicas[domain];
     if (!replica) return;

--- a/packages/sdk/src/CoreContracts.ts
+++ b/packages/sdk/src/CoreContracts.ts
@@ -29,7 +29,8 @@ export class CoreContracts<T extends NomadContext> extends Contracts<
     this.conf = conf;
   }
 
-  getReplica(domain: string): core.Replica | undefined {
+  getReplica(nameOrDomain: string | number): core.Replica | undefined {
+    const domain = this.context.resolveDomain(nameOrDomain);
     if (!this.connection) throw new NoProviderError(this.context, domain);
     const replica = this.conf.replicas[domain];
     if (!replica) return;

--- a/packages/sdk/src/NomadContext.ts
+++ b/packages/sdk/src/NomadContext.ts
@@ -138,8 +138,7 @@ export class NomadContext extends MultiProvider<config.Domain> {
     home: string | number,
     remote: string | number,
   ): core.Replica | undefined {
-    const homeDomain = this.resolveDomainName(home);
-    return this.getCore(remote)?.getReplica(homeDomain);
+    return this.getCore(remote)?.getReplica(home);
   }
 
   /**

--- a/packages/sdk/tests/index.test.ts
+++ b/packages/sdk/tests/index.test.ts
@@ -76,6 +76,15 @@ describe('sdk', async () => {
     // TODO:
     it.skip('fails if given bad rpc provider string');
 
+    it('gets replica by name or domain', () => {
+      const context = new NomadContext('development');
+      const core = context.mustGetCore(2000);
+      const replica = core.getReplica(3000);
+      expect(replica).to.not.be.undefined;
+      const replicaFor = context.getReplicaFor(2000, 3000);
+      expect(replicaFor).to.not.be.undefined;
+    })
+
     it('maintains connection when registering and unregistering signers', () => {
       const conf = config.getBuiltin('development');
       const context = new NomadContext(conf);

--- a/packages/sdk/tests/index.test.ts
+++ b/packages/sdk/tests/index.test.ts
@@ -59,8 +59,7 @@ describe('sdk', async () => {
           }
 
           // returns undefined if no replica exists
-          const noReplica = core.getReplica('none');
-          expect(noReplica).to.be.undefined;
+          expect(() => core.getReplica('none')).to.throw;
         }
       }
     });
@@ -78,6 +77,8 @@ describe('sdk', async () => {
 
     it('gets replica by name or domain', () => {
       const context = new NomadContext('development');
+      context.registerRpcProvider(2000, 'http://dummy-rpc-url');
+      context.registerRpcProvider(3000, 'http://dummy-rpc-url');
       const core = context.mustGetCore(2000);
       const replica = core.getReplica(3000);
       expect(replica).to.not.be.undefined;

--- a/yarn.lock
+++ b/yarn.lock
@@ -6877,7 +6877,7 @@ __metadata:
   dependencies:
     bn.js: ^4.11.8
     ethereumjs-util: ^6.0.0
-  checksum: 03127d09960e5f8a44167463faf25b2894db2f746376dbb8195b789ed11762f93db9c574eaa7c498c400063508e9dfc1c80de2edf5f0e1406b25c87d860ff2f1
+  checksum: ae074be0bb012857ab5d3ae644d1163b908a48dd724b7d2567cfde309dc72222d460438f2411936a70dc949dc604ce1ef7118f7273bd525815579143c907e336
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Closes #156

`getReplica` on NomadContext only accepts domain number where everything else accepts nameOrDomain

## Solution

Pass in nameOrDomain, resolveDomain

## PR Checklist

- [x] Added Tests
- [x] Updated Documentation
- [x] Updated CHANGELOG.md for the appropriate package
