### PR TITLE
chore: npmignore tsconfig files

### DIFF
--- a/packages/deploy/.npmignore
+++ b/packages/deploy/.npmignore
@@ -4,3 +4,5 @@ dist/
 .env
 config/
 scripts/
+tsconfig.json
+tsconfig.tsbuildinfo

--- a/packages/multi-provider/.npmignore
+++ b/packages/multi-provider/.npmignore
@@ -4,3 +4,4 @@ tmp.ts
 config/
 scripts/
 tests/
+tsconfig.json

--- a/packages/new-deploy/.npmignore
+++ b/packages/new-deploy/.npmignore
@@ -1,6 +1,8 @@
 node_modules/
 tmp.ts
-dist/
 .env
 config/
 scripts/
+tests/
+tsconfig.json
+tsconfig.tsbuildinfo

--- a/packages/sdk-bridge/.npmignore
+++ b/packages/sdk-bridge/.npmignore
@@ -4,3 +4,5 @@ tmp.ts
 config/
 scripts/
 tests/
+tsconfig.json
+tsconfig.tsbuildino

--- a/packages/sdk-govern/.npmignore
+++ b/packages/sdk-govern/.npmignore
@@ -4,3 +4,5 @@ tmp.ts
 config/
 scripts/
 tests/
+tsconfig.json
+tsconfig.tsbuildinfo

--- a/packages/sdk/.npmignore
+++ b/packages/sdk/.npmignore
@@ -4,3 +4,5 @@ tmp.ts
 config/
 scripts/
 tests/
+tsconfig.json
+tsconfig.tsbuildinfo


### PR DESCRIPTION
## Motivation

we're currently npm publishing files that are useless or damaging to library installers

## Solution

npmignore 'em 😎 

## PR Checklist

- [n/a] Added Tests
- [n/a] Updated Documentation
- [n/a] Updated CHANGELOG.md for the appropriate package
