### PR TITLE
fix: initial root for replica

### DIFF
--- a/packages/new-deploy/src/core/CoreContracts.ts
+++ b/packages/new-deploy/src/core/CoreContracts.ts
@@ -379,7 +379,7 @@ export default class EvmCoreDeploy extends AbstractCoreDeploy<config.EvmCoreCont
     const home = this.context.resolveDomainName(homeDomain);
     const localConfig = this.context.mustGetDomainConfig(local);
     const homeConfig = this.context.mustGetDomainConfig(home);
-    const homeCore = this.context.mustGetCore(local);
+    const homeCore = this.context.mustGetCore(home);
 
     // don't redeploy existing replica
     if (this.data.replicas && this.data.replicas[home]) return;


### PR DESCRIPTION
## Motivation

There is a bug in the deploy script which causes Replica contracts to be initialized with the current root for the wrong Home contract.

## Solution

Get the correct set of Core contracts for the Home before querying the current root

## PR Checklist

- [ ] Added Tests
- [ ] Updated Documentation
- [ ] Updated CHANGELOG.md for the appropriate package
