### PR TITLE
fix: include goerli overrides in new-deploy

### DIFF
--- a/packages/new-deploy/changelog.md
+++ b/packages/new-deploy/changelog.md
@@ -2,4 +2,5 @@
 
 ### Unreleased
 
+- fix: add goerli overrides to overrides.json
 - feature: Added core and bridge checks

--- a/packages/new-deploy/config/development/overrides.json
+++ b/packages/new-deploy/config/development/overrides.json
@@ -13,6 +13,11 @@
     "maxPriorityFeePerGas": "2500000000",
     "gasLimit": "7000000"
   },
+  "goerli": {
+    "maxFeePerGas": "4000000000",
+    "maxPriorityFeePerGas": "2500000000",
+    "gasLimit": "7000000"
+  },
   "moonbasealpha": {
     "maxFeePerGas": "20000000000",
     "maxPriorityFeePerGas": "2000000000",


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below. Bug fixes and new features should include tests.

New contributors should read the contributors guide:
https://github.com/nomad-xyz/monorepo/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building
the documentation.
-->

## Motivation

Deploy script currently breaks when estimating gas on Goerli. 

## Solution

Adds override block to `overrides.json` for Goerli. Script can now run to completion.

## PR Checklist
- [x] Updated CHANGELOG.md for the appropriate package
