### PR TITLE
fix: add watcher to keymaster replica fund set

### DIFF
--- a/packages/keymaster/changelog.md
+++ b/packages/keymaster/changelog.md
@@ -1,0 +1,5 @@
+# Changelog
+
+### Unreleased
+
+- add watchers to list of agents needing funds on replica chains

--- a/packages/keymaster/src/keymaster.py
+++ b/packages/keymaster/src/keymaster.py
@@ -113,7 +113,7 @@ def monitor(ctx, metrics_port, pause_duration):
                         statuses.append(status)
 
                     # only process agents that act on the replica
-                    if role in ["relayer", "processor"]:
+                    if role in ["relayer", "processor", "watcher"]:
                         # Get status on Home's replicas for role
                         for replica_name in home["replicas"]:
                             replica_config = config["networks"][replica_name] 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below. Bug fixes and new features should include tests.

New contributors should read the contributors guide:
https://github.com/nomad-xyz/monorepo/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building
the documentation.
-->

## Motivation

Watchers not being funded on replica chains.

## Solution

Add watchers to list of agents that need funding on replica chains.

## PR Checklist

- [ ] Added Tests (N/A)
- [ ] Updated Documentation (N/A)
- [x] Updated CHANGELOG.md for the appropriate package
