### PR TITLE
release: bump multi-provider, sdk, sdk-bridge, sdk-govern + update changelogs

### DIFF
--- a/packages/multi-provider/changelog.md
+++ b/packages/multi-provider/changelog.md
@@ -2,6 +2,7 @@
 
 ### Unreleased
 
+### 1.0.0-rc.4
 - refactor: additional functionality on the `Contracts` type
 - fix: multi-provider methods that return `Domains` now return the
   `T extends Domain` type associated with the multi-provider

--- a/packages/multi-provider/package.json
+++ b/packages/multi-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nomad-xyz/multi-provider",
-  "version": "1.0.0-rc.3",
+  "version": "1.0.0-rc.4",
   "description": "A wrapper for multiple ethers.js providers, suitable for multi-chain applications",
   "keywords": [
     "nomad",

--- a/packages/new-deploy/changelog.md
+++ b/packages/new-deploy/changelog.md
@@ -6,3 +6,6 @@
 - feature: Added core and bridge checks
 - chore: bump configuration to v0.1.0-rc.9
 - fix: core check for watchers
+- chore: bump multi-provider to v1.0.0-rc.4
+- chore: bump sdk to v2.0.0-rc.6
+- chore: bump sdk-govern to v1.0.0-rc.5

--- a/packages/new-deploy/package.json
+++ b/packages/new-deploy/package.json
@@ -17,7 +17,7 @@
     "typescript": "^4.5.5"
   },
   "private": true,
-  "version": "0.1.3",
+  "version": "0.0.0-rc.0",
   "description": "Nomad deploy tools",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/sdk-bridge/changelog.md
+++ b/packages/sdk-bridge/changelog.md
@@ -2,6 +2,10 @@
 
 ### Unreleased
 
+### 1.0.0-rc.6
+
+- chore: bump sdk to v2.0.0-rc.6
+
 ### 1.0.0-rc.5
 
 - refactor: simpler connection logic (deleting `reconnect`)

--- a/packages/sdk-bridge/package.json
+++ b/packages/sdk-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nomad-xyz/sdk-bridge",
-  "version": "1.0.0-rc.5",
+  "version": "1.0.0-rc.6",
   "description": "Nomad bridge SDK",
   "keywords": [
     "nomad",

--- a/packages/sdk-govern/changelog.md
+++ b/packages/sdk-govern/changelog.md
@@ -2,6 +2,9 @@
 
 ### Unreleased
 
+### 1.0.0-rc.5
+
+- chore: bump sdk to v2.0.0-rc.6
 
 ### 1.0.0-rc.4
 

--- a/packages/sdk-govern/package.json
+++ b/packages/sdk-govern/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nomad-xyz/sdk-govern",
-  "version": "1.0.0-rc.4",
+  "version": "1.0.0-rc.5",
   "description": "Nomad governance SDK",
   "keywords": [
     "nomad",

--- a/packages/sdk/changelog.md
+++ b/packages/sdk/changelog.md
@@ -2,6 +2,10 @@
 
 ### Unreleased
 
+### 2.0.0-rc.6
+
+- chore: bump multi-provider to v1.0.0-rc.4
+
 ### 2.0.0-rc.5
 
 - refactor: simpler connection logic (deleting `reconnect`)

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nomad-xyz/sdk",
-  "version": "2.0.0-rc.5",
+  "version": "2.0.0-rc.6",
   "description": "Nomad SDK",
   "keywords": [
     "nomad",


### PR DESCRIPTION


## Motivation
multi-provider was not updated and published sp the current sdk package uses an outdated version of multi-provider. sdk-bridge and sdk-govern also affected since they rely on sdk.

## Solution
publish multi-provider and re-publish sdk, sdk-bridge, sdk-govern. semver will enforce in the future once we're not using release candidate versioning (eg v0.0.1-rc.1)


## PR Checklist

- [ ] Added Tests (NA)
- [ ] Updated Documentation (NA)
- [x] Updated CHANGELOG.md for the appropriate package
