### PR TITLE
fix: overrides for milkomeda + rename home -> remote

### DIFF
--- a/packages/new-deploy/config/overrides-production.json
+++ b/packages/new-deploy/config/overrides-production.json
@@ -8,10 +8,6 @@
     "gasPrice": "150000000000",
     "gasLimit": "7000000"
   },
-  "milkomedaC1": {
-    "gasPrice": "150000000000",
-    "gasLimit": "7000000"
-  },
   "xdai": {
     "maxFeePerGas": "20000000000",
     "maxPriorityFeePerGas": "2500000000",


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below. Bug fixes and new features should include tests.

New contributors should read the contributors guide:
https://github.com/nomad-xyz/monorepo/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building
the documentation.
-->

## Motivation

- milkomeda overrides were throwing, need to be removed
- "home" was more confusing naming in deploy script, making it harder for developers to understand

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

- remove the overrides for milkomeda
- rename home -> remote in deploy script
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Updated Documentation
- [ ] Updated CHANGELOG.md for the appropriate package
