### PR TITLE
feature: restart-safe deploys

### DIFF
--- a/packages/new-deploy/README.md
+++ b/packages/new-deploy/README.md
@@ -9,8 +9,8 @@ process based on the Nomad configuration format.
 This package is feature-complete and we have big plans for the future :)
 
 - Run a fresh deploy with no networks
-- Extend a current deployment
-- Future: gracefully resume partial deployments
+- Extend a current deployment with new networks or connections
+- Gracefully resume partial deployments by re-running the script
 - Future: automatically submit gnosis SAFE batches if configured
 
 ### Invocation
@@ -23,7 +23,16 @@ $ yarn run ts-node scripts/deploy.ts path/to/config.json path/to/overrides.json
 ```
 
 The deployer will output the new config file, the contract verification
-information, and any governance actions that need to be taken
+information, and any governance actions that need to be taken.
+
+If the deploy script errors during the process, the partial config 
+and verification inputs will still be output, so that contracts deployed
+are not lost. 
+
+Governance transactions are idempotent;
+if the state on-chain doesn't change,
+the same config will deterministically produce 
+the same set of governance transactions.
 
 ### Verification
 

--- a/packages/new-deploy/changelog.md
+++ b/packages/new-deploy/changelog.md
@@ -9,3 +9,4 @@
 - chore: bump multi-provider to v1.0.0-rc.4
 - chore: bump sdk to v2.0.0-rc.6
 - chore: bump sdk-govern to v1.0.0-rc.5
+- feature: make deploys re-start safe

--- a/packages/new-deploy/package.json
+++ b/packages/new-deploy/package.json
@@ -34,7 +34,7 @@
   "author": "Illusory Systems Inc.",
   "license": "MIT OR Apache-2.0",
   "dependencies": {
-    "@nomad-xyz/configuration": "^0.1.0-rc.11",
+    "@nomad-xyz/configuration": "^0.1.0-rc.12",
     "@nomad-xyz/contracts-bridge": "workspace:^",
     "@nomad-xyz/contracts-core": "workspace:^",
     "@nomad-xyz/contracts-router": "workspace:^",

--- a/packages/new-deploy/package.json
+++ b/packages/new-deploy/package.json
@@ -34,7 +34,7 @@
   "author": "Illusory Systems Inc.",
   "license": "MIT OR Apache-2.0",
   "dependencies": {
-    "@nomad-xyz/configuration": "^0.1.0-rc.10",
+    "@nomad-xyz/configuration": "^0.1.0-rc.11",
     "@nomad-xyz/contracts-bridge": "workspace:^",
     "@nomad-xyz/contracts-core": "workspace:^",
     "@nomad-xyz/contracts-router": "workspace:^",

--- a/packages/new-deploy/scripts/deploy.ts
+++ b/packages/new-deploy/scripts/deploy.ts
@@ -35,7 +35,7 @@ async function run() {
 
     outputConfigAndVerification(outputDir, deployContext);
 
-    if (governanceBatch) {
+    if (governanceBatch && !governanceBatch.isEmpty()) {
       // build & write governance batch
       await governanceBatch.build();
       fs.writeFileSync(

--- a/packages/new-deploy/scripts/deploy.ts
+++ b/packages/new-deploy/scripts/deploy.ts
@@ -60,7 +60,7 @@ function outputConfigAndVerification(outputDir: string, deployContext: DeployCon
       JSON.stringify(deployContext.data, null, 2),
   );
   fs.writeFileSync(
-      `${outputDir}/verification.json`,
+      `${outputDir}/verification-${Date.now()}.json`,
       JSON.stringify(Object.fromEntries(deployContext.verification), null, 2),
   );
 }

--- a/packages/new-deploy/scripts/deploy.ts
+++ b/packages/new-deploy/scripts/deploy.ts
@@ -53,14 +53,19 @@ async function run() {
 }
 
 function outputConfigAndVerification(outputDir: string, deployContext: DeployContext) {
-  // output the updated config & verification inputs
+  // output the config
   fs.mkdirSync(outputDir, {recursive: true});
   fs.writeFileSync(
       `${outputDir}/config.json`,
       JSON.stringify(deployContext.data, null, 2),
   );
-  fs.writeFileSync(
-      `${outputDir}/verification-${Date.now()}.json`,
-      JSON.stringify(Object.fromEntries(deployContext.verification), null, 2),
-  );
+  // if new contracts were deployed,
+  const verification = Object.fromEntries(deployContext.verification);
+  if (Object.keys(verification).length > 0) {
+    // output the verification inputs
+    fs.writeFileSync(
+        `${outputDir}/verification-${Date.now()}.json`,
+        JSON.stringify(verification, null, 2),
+    );
+  }
 }

--- a/packages/new-deploy/scripts/deploy.ts
+++ b/packages/new-deploy/scripts/deploy.ts
@@ -29,28 +29,38 @@ async function run() {
     deployContext.overrides.set(network, OVERRIDES[network]);
   }
   // run the deploy script
-  const governanceBatch = await deployContext.deployAndRelinquish();
-
-  // output the updated config & verification inputs
   const outputDir = './output';
-  fs.mkdirSync(outputDir, { recursive: true });
-  fs.writeFileSync(
-    `${outputDir}/config.json`,
-    JSON.stringify(deployContext.data, null, 2),
-  );
-  fs.writeFileSync(
-    `${outputDir}/verification.json`,
-    JSON.stringify(Object.fromEntries(deployContext.verification), null, 2),
-  );
+  try {
+    const governanceBatch = await deployContext.deployAndRelinquish();
 
-  if (governanceBatch) {
+    outputConfigAndVerification(outputDir, deployContext);
+
+    if (governanceBatch) {
       // build & write governance batch
       await governanceBatch.build();
       fs.writeFileSync(
           `${outputDir}/governanceTransactions.json`,
           JSON.stringify(governanceBatch, null, 2),
       );
-  }
+    }
 
-  console.log(`DONE!`);
+    console.log(`DONE!`);
+  } catch (e) {
+    outputConfigAndVerification(outputDir, deployContext);
+    
+    throw e;
+  }
+}
+
+function outputConfigAndVerification(outputDir: string, deployContext: DeployContext) {
+  // output the updated config & verification inputs
+  fs.mkdirSync(outputDir, {recursive: true});
+  fs.writeFileSync(
+      `${outputDir}/config.json`,
+      JSON.stringify(deployContext.data, null, 2),
+  );
+  fs.writeFileSync(
+      `${outputDir}/verification.json`,
+      JSON.stringify(Object.fromEntries(deployContext.verification), null, 2),
+  );
 }

--- a/packages/sdk-bridge/package.json
+++ b/packages/sdk-bridge/package.json
@@ -33,7 +33,7 @@
     "coverage": "nyc --reporter=html ts-mocha ./tests/*.ts"
   },
   "dependencies": {
-    "@nomad-xyz/configuration": "^0.1.0-rc.10",
+    "@nomad-xyz/configuration": "^0.1.0-rc.12",
     "@nomad-xyz/contracts-bridge": "workspace:^",
     "@nomad-xyz/sdk": "workspace:^",
     "ethers": "^5.0.0",

--- a/packages/sdk-govern/package.json
+++ b/packages/sdk-govern/package.json
@@ -36,7 +36,7 @@
     "@gnosis.pm/safe-core-sdk": "^2.0.0",
     "@gnosis.pm/safe-ethers-adapters": "^0.1.0-alpha.8",
     "@gnosis.pm/safe-ethers-lib": "^1.0.0",
-    "@nomad-xyz/configuration": "^0.1.0-rc.10",
+    "@nomad-xyz/configuration": "^0.1.0-rc.12",
     "@nomad-xyz/sdk": "workspace:^",
     "ethers": "^5.4.6",
     "web3": "^1.6.1"

--- a/packages/sdk-govern/src/index.ts
+++ b/packages/sdk-govern/src/index.ts
@@ -111,6 +111,14 @@ export class CallBatch {
     return Array.from(this.remote.keys());
   }
 
+  get remoteDomains(): number[] {
+    return Array.from(this.remote.keys());
+  }
+
+  isEmpty(): boolean {
+    return this.local.length == 0 && this.remoteDomains.length == 0;
+  }
+
   pushLocal(call: Call): void {
     if (this.built)
       throw new Error('Batch has been built. Cannot push more calls');

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -32,7 +32,7 @@
     "coverage": "nyc --reporter=html ts-mocha ./tests/*.ts"
   },
   "dependencies": {
-    "@nomad-xyz/configuration": "^0.1.0-rc.10",
+    "@nomad-xyz/configuration": "^0.1.0-rc.12",
     "@nomad-xyz/contracts-core": "workspace:^",
     "@nomad-xyz/multi-provider": "workspace:^",
     "ethers": "^5.0.0"

--- a/packages/sdk/tests/index.test.ts
+++ b/packages/sdk/tests/index.test.ts
@@ -68,8 +68,8 @@ describe('sdk', async () => {
       const conf = config.getBuiltin('development');
       const context = new NomadContext(conf);
       const signer = new VoidSigner(constants.AddressZero);
-      const err = 'Missing provider for domain: 2000 : rinkeby';
-      expect(() => context.registerSigner(2000, signer)).to.throw(err);
+      const err = 'Missing provider for domain: 1001 : rinkeby.\nHint: Have you called `context.registerProvider(1001, provider)` yet?';
+      expect(() => context.registerSigner(1001, signer)).to.throw(err);
     });
 
     // TODO:
@@ -77,12 +77,12 @@ describe('sdk', async () => {
 
     it('gets replica by name or domain', () => {
       const context = new NomadContext('development');
-      context.registerRpcProvider(2000, 'http://dummy-rpc-url');
-      context.registerRpcProvider(3000, 'http://dummy-rpc-url');
-      const core = context.mustGetCore(2000);
-      const replica = core.getReplica(3000);
+      context.registerRpcProvider(2001, 'http://dummy-rpc-url');
+      context.registerRpcProvider(3001, 'http://dummy-rpc-url');
+      const core = context.mustGetCore(2001);
+      const replica = core.getReplica(3001);
       expect(replica).to.not.be.undefined;
-      const replicaFor = context.getReplicaFor(2000, 3000);
+      const replicaFor = context.getReplicaFor(2001, 3001);
       expect(replicaFor).to.not.be.undefined;
     });
 
@@ -94,13 +94,13 @@ describe('sdk', async () => {
       context.domainNames.forEach((domain) => {
         context.registerProvider(domain, provider);
       });
-      context.registerSigner(2000, signer);
-      context.registerSigner(3000, signer);
-      context.unregisterSigner(2000);
-      expect(context.getConnection(2000)).to.not.be.undefined;
+      context.registerSigner(2001, signer);
+      context.registerSigner(3001, signer);
+      context.unregisterSigner(2001);
+      expect(context.getConnection(2001)).to.not.be.undefined;
       context.clearSigners();
-      expect(context.getConnection(2000)).to.not.be.undefined;
-      expect(context.getConnection(3000)).to.not.be.undefined;
+      expect(context.getConnection(2001)).to.not.be.undefined;
+      expect(context.getConnection(3001)).to.not.be.undefined;
     });
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1192,17 +1192,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@nomad-xyz/configuration@npm:^0.1.0-rc.10":
-  version: 0.1.0-rc.10
-  resolution: "@nomad-xyz/configuration@npm:0.1.0-rc.10"
-  checksum: 8917abd840bfc2247609b7c70134488dee39035d1c37a53455141be60d4b4a6171f62fe48d7b5ce70ea8712211ff04d502869e5b90bdd3adef3fd8009826ef48
-  languageName: node
-  linkType: hard
-
-"@nomad-xyz/configuration@npm:^0.1.0-rc.11":
-  version: 0.1.0-rc.11
-  resolution: "@nomad-xyz/configuration@npm:0.1.0-rc.11"
-  checksum: 87af058cf23be6f4e02a1450a52f37b5ac469e400873be476d12d10dc57dd50ddb671b51a03477dd1e3d3e5996c918bcfea001c1775fd9074e25ade4339a1a6d
+"@nomad-xyz/configuration@npm:^0.1.0-rc.12":
+  version: 0.1.0-rc.12
+  resolution: "@nomad-xyz/configuration@npm:0.1.0-rc.12"
+  checksum: 379f404406a2556ad84a0533ffb03945c05fd571b71c4efd4b6b26321afc8e48d037101fcce6ebf36c4a5eedd5f9dafa43bc7a233c82a4c1009c04ed76469ef1
   languageName: node
   linkType: hard
 
@@ -1424,7 +1417,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@nomad-xyz/new-deploy@workspace:packages/new-deploy"
   dependencies:
-    "@nomad-xyz/configuration": ^0.1.0-rc.11
+    "@nomad-xyz/configuration": ^0.1.0-rc.12
     "@nomad-xyz/contracts-bridge": "workspace:^"
     "@nomad-xyz/contracts-core": "workspace:^"
     "@nomad-xyz/contracts-router": "workspace:^"
@@ -1454,7 +1447,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@nomad-xyz/sdk-bridge@workspace:packages/sdk-bridge"
   dependencies:
-    "@nomad-xyz/configuration": ^0.1.0-rc.10
+    "@nomad-xyz/configuration": ^0.1.0-rc.12
     "@nomad-xyz/contracts-bridge": "workspace:^"
     "@nomad-xyz/sdk": "workspace:^"
     "@types/chai": ^4.2.21
@@ -1483,7 +1476,7 @@ __metadata:
     "@gnosis.pm/safe-core-sdk": ^2.0.0
     "@gnosis.pm/safe-ethers-adapters": ^0.1.0-alpha.8
     "@gnosis.pm/safe-ethers-lib": ^1.0.0
-    "@nomad-xyz/configuration": ^0.1.0-rc.10
+    "@nomad-xyz/configuration": ^0.1.0-rc.12
     "@nomad-xyz/sdk": "workspace:^"
     "@types/chai": ^4.2.21
     "@types/mocha": ^9.1.0
@@ -1508,7 +1501,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@nomad-xyz/sdk@workspace:packages/sdk"
   dependencies:
-    "@nomad-xyz/configuration": ^0.1.0-rc.10
+    "@nomad-xyz/configuration": ^0.1.0-rc.12
     "@nomad-xyz/contracts-core": "workspace:^"
     "@nomad-xyz/local-environment": "workspace:^"
     "@nomad-xyz/multi-provider": "workspace:^"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1199,6 +1199,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@nomad-xyz/configuration@npm:^0.1.0-rc.11":
+  version: 0.1.0-rc.11
+  resolution: "@nomad-xyz/configuration@npm:0.1.0-rc.11"
+  checksum: 87af058cf23be6f4e02a1450a52f37b5ac469e400873be476d12d10dc57dd50ddb671b51a03477dd1e3d3e5996c918bcfea001c1775fd9074e25ade4339a1a6d
+  languageName: node
+  linkType: hard
+
 "@nomad-xyz/contract-interfaces@npm:1.1.1":
   version: 1.1.1
   resolution: "@nomad-xyz/contract-interfaces@npm:1.1.1"
@@ -1417,7 +1424,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@nomad-xyz/new-deploy@workspace:packages/new-deploy"
   dependencies:
-    "@nomad-xyz/configuration": ^0.1.0-rc.10
+    "@nomad-xyz/configuration": ^0.1.0-rc.11
     "@nomad-xyz/contracts-bridge": "workspace:^"
     "@nomad-xyz/contracts-core": "workspace:^"
     "@nomad-xyz/contracts-router": "workspace:^"


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below. Bug fixes and new features should include tests.

New contributors should read the contributors guide:
https://github.com/nomad-xyz/monorepo/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building
the documentation.
-->

## Motivation

when deploy fails, you have to start from scratch again. we want to save the deployed contracts in the config and the verification inputs so we can restart gracefully

closes #115 

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

wrap the deploy invocation in a try/catch and cache the config and verification when it fails

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [x] FIX: re-running the script clobbers old verification outputs
- [x] FIX: writing empty verification inputs
- [x] FIX: writing empty governance transactions
- [ ] FIX: partial configs throw with rust verification #216 
- [ ] Added Tests
- [x] Updated Documentation
- [x] Updated CHANGELOG.md for the appropriate package
