### PR TITLE
add: process method on NomadContext

### DIFF
--- a/packages/sdk/changelog.md
+++ b/packages/sdk/changelog.md
@@ -2,6 +2,8 @@
 
 ### Unreleased
 
+- feature: process function for NomadContext/NomadMessage
+
 ### 2.0.0-rc.9
 
 - update typescript eslint packages to fix lint script

--- a/packages/sdk/src/NomadContext.ts
+++ b/packages/sdk/src/NomadContext.ts
@@ -217,10 +217,6 @@ export class NomadContext extends MultiProvider<config.Domain> {
     // get replica contract
     const replica = this.mustGetReplicaFor(originNetwork, destNetwork);
 
-    // get signer and connect replica
-    const signer = this.mustGetSigner(destNetwork);
-    replica.connect(signer);
-
     return replica.proveAndProcess(
       data.message,
       data.proof.path,

--- a/packages/sdk/src/NomadContext.ts
+++ b/packages/sdk/src/NomadContext.ts
@@ -5,7 +5,7 @@ import * as core from '@nomad-xyz/contracts-core';
 import * as config from '@nomad-xyz/configuration';
 
 import { CoreContracts } from './CoreContracts';
-import { NomadMessage } from './messages/NomadMessage'
+import { NomadMessage } from './messages/NomadMessage';
 
 export type Address = string;
 
@@ -58,7 +58,7 @@ export class NomadContext extends MultiProvider<config.Domain> {
         this.registerRpcProvider(network, this.conf.rpcs[network][0]);
       }
       // set core contracts
-      const core = new CoreContracts(this, network, this.conf.core[network])
+      const core = new CoreContracts(this, network, this.conf.core[network]);
       this._cores.set(core.domain, core);
     }
   }
@@ -68,7 +68,7 @@ export class NomadContext extends MultiProvider<config.Domain> {
   }
 
   get environment(): string {
-    return this.conf.environment
+    return this.conf.environment;
   }
 
   /**
@@ -205,27 +205,27 @@ export class NomadContext extends MultiProvider<config.Domain> {
    * @returns The Contract Transaction receipt
    */
   async process(message: NomadMessage<NomadContext>): Promise<ContractTransaction>{
-    const s3URL = `https://nomadxyz-${this.environment}-proofs.s3.us-west-2.amazonaws.com/`
+    const s3URL = `https://nomadxyz-${this.environment}-proofs.s3.us-west-2.amazonaws.com/`;
 
-    const originNetwork = this.resolveDomainName(message.origin)
-    const destNetwork = this.resolveDomainName(message.destination)
-    const index = message.leafIndex.toString()
-    const s3Res = await fetch(`${s3URL}${originNetwork}_${index}`)
-    if (!s3Res) throw new Error('Not able to fetch proof')
-    const data: MessageProof = await s3Res.json()
+    const originNetwork = this.resolveDomainName(message.origin);
+    const destNetwork = this.resolveDomainName(message.destination);
+    const index = message.leafIndex.toString();
+    const s3Res = await fetch(`${s3URL}${originNetwork}_${index}`);
+    if (!s3Res) throw new Error('Not able to fetch proof');
+    const data: MessageProof = await s3Res.json();
 
     // get replica contract
-    const replica = this.mustGetReplicaFor(originNetwork, destNetwork)
+    const replica = this.mustGetReplicaFor(originNetwork, destNetwork);
 
     // get signer and connect replica
-    const signer = this.mustGetSigner(destNetwork)
-    replica.connect(signer)
+    const signer = this.mustGetSigner(destNetwork);
+    replica.connect(signer);
 
     return replica.proveAndProcess(
       data.message,
       data.proof.path,
       data.proof.index
-    )
+    );
   }
 
   blacklist(): Set<number> {

--- a/packages/sdk/src/NomadContext.ts
+++ b/packages/sdk/src/NomadContext.ts
@@ -211,6 +211,7 @@ export class NomadContext extends MultiProvider<config.Domain> {
     const destNetwork = this.resolveDomainName(message.destination)
     const index = message.leafIndex.toString()
     const s3Res = await fetch(`${s3URL}${originNetwork}_${index}`)
+    if (!s3Res) throw new Error('Not able to fetch proof')
     const data: MessageProof = await s3Res.json()
 
     // get replica contract

--- a/packages/sdk/src/NomadContext.ts
+++ b/packages/sdk/src/NomadContext.ts
@@ -1,4 +1,4 @@
-import { providers, Signer, ContractTransaction } from 'ethers';
+import { providers, Signer, ContractTransaction, BytesLike } from 'ethers';
 
 import { MultiProvider } from '@nomad-xyz/multi-provider';
 import * as core from '@nomad-xyz/contracts-core';
@@ -8,11 +8,13 @@ import { CoreContracts } from './CoreContracts';
 import { NomadMessage } from './messages/NomadMessage'
 
 export type Address = string;
-
-const s3URLs: { [key: string]: string } = {
-  production: 'https://nomadxyz-production-proofs.s3.us-west-2.amazonaws.com/',
-  development: 'https://nomadxyz-development-proofs.s3.us-west-2.amazonaws.com/',
-  staging: 'https://nomadxyz-staging-proofs.s3.us-west-2.amazonaws.com/'
+type MessageProof = {
+  message: BytesLike;
+  proof: {
+    leaf: BytesLike;
+    index: number;
+    path: [BytesLike, BytesLike, BytesLike, BytesLike, BytesLike, BytesLike, BytesLike, BytesLike, BytesLike, BytesLike, BytesLike, BytesLike, BytesLike, BytesLike, BytesLike, BytesLike, BytesLike, BytesLike, BytesLike, BytesLike, BytesLike, BytesLike, BytesLike, BytesLike, BytesLike, BytesLike, BytesLike, BytesLike, BytesLike, BytesLike, BytesLike, BytesLike];
+  }
 }
 
 /**
@@ -60,6 +62,10 @@ export class NomadContext extends MultiProvider<config.Domain> {
 
   get governor(): config.NomadLocator {
     return this.conf.protocol.governor;
+  }
+
+  get environment(): string {
+    return this.conf.environment
   }
 
   /**
@@ -187,39 +193,31 @@ export class NomadContext extends MultiProvider<config.Domain> {
    * 
    * @dev Ensure that a transaction is ready to be processed. You should ensure the following
    * criteria have been met prior to calling this function:
-   *  1. the tx has been relayed
-   *  2. the `confirmAt` timestamp for the tx is in the past
-   *  3. the user is on the destination chain in their wallet
+   *  1. The tx has been relayed (has status of 2):
+   *       `const { status } = await NomadMessage.events()`
+   *  2. The `confirmAt` timestamp for the tx is in the past:
+   *       `const confirmAt = await NomadMessage.confirmAt()`
    *
+   * @param message NomadMessage
    * @returns The Contract Transaction receipt
    */
-  async process(origin: string | number, txId: string): Promise<ContractTransaction>{
-    // get s3 proof URL for environment
-    const { environment } = this.conf
-    const s3URL = s3URLs[environment]
-
-    const message = (await NomadMessage.baseFromTransactionHash(
-      this,
-      origin,
-      txId
-    ))[0]
+  async process(message: NomadMessage<NomadContext>): Promise<ContractTransaction>{
+    const s3URL = `https://nomadxyz-${this.environment}-proofs.s3.us-west-2.amazonaws.com/`
 
     const originNetwork = this.resolveDomainName(message.origin)
     const destNetwork = this.resolveDomainName(message.destination)
     const index = message.leafIndex.toString()
     const s3Res = await fetch(`${s3URL}${originNetwork}_${index}`)
-    const data = (await s3Res.json()) as any
+    const data: MessageProof = await s3Res.json()
 
     // get replica contract
-    const replica = this.getReplicaFor(originNetwork, destNetwork)
-    if (!replica) throw new Error('missing replica, unable to process transaction')
+    const replica = this.mustGetReplicaFor(originNetwork, destNetwork)
 
     // get signer and connect replica
-    const signer = this.getSigner(destNetwork)
-    if (!signer) throw new Error('missing signer, unable to process transaction')
+    const signer = this.mustGetSigner(destNetwork)
     replica.connect(signer)
 
-    return await replica.proveAndProcess(
+    return replica.proveAndProcess(
       data.message,
       data.proof.path,
       data.proof.index

--- a/packages/sdk/src/NomadContext.ts
+++ b/packages/sdk/src/NomadContext.ts
@@ -5,8 +5,15 @@ import * as core from '@nomad-xyz/contracts-core';
 import * as config from '@nomad-xyz/configuration';
 
 import { CoreContracts } from './CoreContracts';
+import { NomadMessage } from './messages/NomadMessage'
 
 export type Address = string;
+
+const s3URLs: { [key: string]: string } = {
+  production: 'https://nomadxyz-production-proofs.s3.us-west-2.amazonaws.com/',
+  development: 'https://nomadxyz-development-proofs.s3.us-west-2.amazonaws.com/',
+  staging: 'https://nomadxyz-staging-proofs.s3.us-west-2.amazonaws.com/'
+}
 
 /**
  * The NomadContext manages connections to Nomad core and Bridge contracts.
@@ -174,33 +181,41 @@ export class NomadContext extends MultiProvider<config.Domain> {
     return this.mustGetCore(this.governor.domain);
   }
 
-  async process(txId: string): Promise<ContractTransaction>{
-    const isProduction = this.conf.environment === 'production'
-    const nomadAPI = isProduction
-      ? 'https://bridge-indexer.prod.madlads.tools/tx/'
-      : 'https://bridge-indexer.dev.madlads.tools/tx/'
-    const s3URL = isProduction
-      ? 'https://nomadxyz-production-proofs.s3.us-west-2.amazonaws.com/'
-      : 'https://nomadxyz-development-proofs.s3.us-west-2.amazonaws.com/'
+  /**
+   * Proves and Processes a transaction on the destination chain. This is subsidize and
+   * automatic on non-Ethereum destinations
+   * 
+   * @dev Ensure that a transaction is ready to be processed. You should ensure the following
+   * criteria have been met prior to calling this function:
+   *  1. the tx has been relayed
+   *  2. the `confirmAt` timestamp for the tx is in the past
+   *  3. the user is on the destination chain in their wallet
+   *
+   * @returns The Contract Transaction receipt
+   */
+  async process(origin: string | number, txId: string): Promise<ContractTransaction>{
+    // get s3 proof URL for environment
+    const { environment } = this.conf
+    const s3URL = s3URLs[environment]
 
-    // get transfer message
-    const res = await fetch(`${nomadAPI}${txId}`)
-    const tx = (await res.json())[0] as any
+    const message = (await NomadMessage.baseFromTransactionHash(
+      this,
+      origin,
+      txId
+    ))[0]
 
-    // get proof
-    const index = BigNumber.from(tx.leafIndex).toNumber()
-    const originName = this.resolveDomainName(tx.origin)
-    const s3Res = await fetch(`${s3URL}${originName}_${index}`)
+    const originNetwork = this.resolveDomainName(message.origin)
+    const destNetwork = this.resolveDomainName(message.destination)
+    const index = message.leafIndex.toString()
+    const s3Res = await fetch(`${s3URL}${originNetwork}_${index}`)
     const data = (await s3Res.json()) as any
-    console.log('proof: ', data)
 
     // get replica contract
-    const replica = this.getReplicaFor(tx.origin, tx.destination)
-
+    const replica = this.getReplicaFor(originNetwork, destNetwork)
     if (!replica) throw new Error('missing replica, unable to process transaction')
 
     // get signer and connect replica
-    const signer = this.getSigner(tx.destination)
+    const signer = this.getSigner(destNetwork)
     if (!signer) throw new Error('missing signer, unable to process transaction')
     replica.connect(signer)
 

--- a/packages/sdk/src/NomadContext.ts
+++ b/packages/sdk/src/NomadContext.ts
@@ -8,12 +8,15 @@ import { CoreContracts } from './CoreContracts';
 import { NomadMessage } from './messages/NomadMessage'
 
 export type Address = string;
+
+type Path = [BytesLike, BytesLike, BytesLike, BytesLike, BytesLike, BytesLike, BytesLike, BytesLike, BytesLike, BytesLike, BytesLike, BytesLike, BytesLike, BytesLike, BytesLike, BytesLike, BytesLike, BytesLike, BytesLike, BytesLike, BytesLike, BytesLike, BytesLike, BytesLike, BytesLike, BytesLike, BytesLike, BytesLike, BytesLike, BytesLike, BytesLike, BytesLike];
+
 type MessageProof = {
   message: BytesLike;
   proof: {
     leaf: BytesLike;
     index: number;
-    path: [BytesLike, BytesLike, BytesLike, BytesLike, BytesLike, BytesLike, BytesLike, BytesLike, BytesLike, BytesLike, BytesLike, BytesLike, BytesLike, BytesLike, BytesLike, BytesLike, BytesLike, BytesLike, BytesLike, BytesLike, BytesLike, BytesLike, BytesLike, BytesLike, BytesLike, BytesLike, BytesLike, BytesLike, BytesLike, BytesLike, BytesLike, BytesLike];
+    path: Path;
   }
 }
 

--- a/packages/sdk/src/NomadContext.ts
+++ b/packages/sdk/src/NomadContext.ts
@@ -1,4 +1,4 @@
-import { providers, Signer, BigNumber, ContractTransaction } from 'ethers';
+import { providers, Signer, ContractTransaction } from 'ethers';
 
 import { MultiProvider } from '@nomad-xyz/multi-provider';
 import * as core from '@nomad-xyz/contracts-core';

--- a/packages/sdk/src/messages/NomadMessage.ts
+++ b/packages/sdk/src/messages/NomadMessage.ts
@@ -435,7 +435,7 @@ export class NomadMessage<T extends NomadContext> {
   }
 
   async process(): Promise<ContractTransaction> {
-    return this.process()
+    return this.context.process(this)
   }
 
   /**

--- a/packages/sdk/src/messages/NomadMessage.ts
+++ b/packages/sdk/src/messages/NomadMessage.ts
@@ -1,3 +1,4 @@
+import { ContractTransaction } from 'ethers'
 import { BigNumber } from '@ethersproject/bignumber';
 import { arrayify, hexlify } from '@ethersproject/bytes';
 import { TransactionReceipt } from '@ethersproject/abstract-provider';
@@ -431,6 +432,10 @@ export class NomadMessage<T extends NomadContext> {
     }
     const { newRoot } = update.event.args;
     return this.replica.confirmAt(newRoot);
+  }
+
+  async process(): Promise<ContractTransaction> {
+    return this.process()
   }
 
   /**

--- a/packages/sdk/src/messages/NomadMessage.ts
+++ b/packages/sdk/src/messages/NomadMessage.ts
@@ -1,4 +1,4 @@
-import { ContractTransaction } from 'ethers'
+import { ContractTransaction } from 'ethers';
 import { BigNumber } from '@ethersproject/bignumber';
 import { arrayify, hexlify } from '@ethersproject/bytes';
 import { TransactionReceipt } from '@ethersproject/abstract-provider';
@@ -435,7 +435,7 @@ export class NomadMessage<T extends NomadContext> {
   }
 
   async process(): Promise<ContractTransaction> {
-    return this.context.process(this)
+    return this.context.process(this);
   }
 
   /**


### PR DESCRIPTION
Closes #134 

Adds process method to the sdk

## Motivation

We should make this more accessible for other applications using our sdk. Decided to add to NomadContext so any messages could be processed, not just Bridge messages.

## Solution

 - Fetch transaction details from Indexer API
 - Fetch proof from S3
 - Ensure signer is registered
 - Call `proveAndProcess` on Replica

## PR Checklist

- [ ] Added Tests
- [x] Updated Documentation
- [ ] Updated CHANGELOG.md for the appropriate package
