### PR TITLE
refactor: store `CallBatch` on `DeployContext`

### DIFF
--- a/packages/new-deploy/changelog.md
+++ b/packages/new-deploy/changelog.md
@@ -10,3 +10,4 @@
 - chore: bump sdk to v2.0.0-rc.6
 - chore: bump sdk-govern to v1.0.0-rc.5
 - feature: make deploys re-start safe
+- store governance CallBatch on DeployContext instead of returning

--- a/packages/new-deploy/src/DeployContext.ts
+++ b/packages/new-deploy/src/DeployContext.ts
@@ -36,6 +36,7 @@ export class DeployContext extends MultiProvider<config.Domain> {
       }
     }
 
+    // instantiate the CallBatch *after* the providers have been registered
     this._callBatch = CallBatch.fromContext(this.asNomadContext);
   }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below. Bug fixes and new features should include tests.

New contributors should read the contributors guide:
https://github.com/nomad-xyz/monorepo/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building
the documentation.
-->

## Motivation

DeployContext was built with Object-Oriented pattern in mind, however, governance transactions (CallBatches) were returned in a functional manner. This made more flexible changes adding new governance transactions more difficult.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Refactor to store the CallBatch on the DeployContext object.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [x] Updated Documentation
- [x] Updated CHANGELOG.md for the appropriate package
