### PR TITLE
fix: paginate with new config

### DIFF
--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Unreleased
 
+- fix: make paginated event querying use the new config layout
+
 ### 2.0.0-rc.10
 
 - feature: process function for NomadContext/NomadMessage

--- a/yarn.lock
+++ b/yarn.lock
@@ -7396,7 +7396,7 @@ __metadata:
   dependencies:
     bn.js: ^4.11.8
     ethereumjs-util: ^6.0.0
-  checksum: ae074be0bb012857ab5d3ae644d1163b908a48dd724b7d2567cfde309dc72222d460438f2411936a70dc949dc604ce1ef7118f7273bd525815579143c907e336
+  checksum: 03127d09960e5f8a44167463faf25b2894db2f746376dbb8195b789ed11762f93db9c574eaa7c498c400063508e9dfc1c80de2edf5f0e1406b25c87d860ff2f1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Motivation

paginated event querying was not updated with the new configuration layout, so querying would never use pages. this breaks most domains

## Solution

Use the new config layout in `fetch.ts`

## PR Checklist

- [ ] Added Tests
- [ ] Updated Documentation
- [x] Updated CHANGELOG.md for the appropriate package
