### PR TITLE
[WIP] Slow Deploys 

### DIFF
--- a/packages/deploy/src/bridge/BridgeContracts.ts
+++ b/packages/deploy/src/bridge/BridgeContracts.ts
@@ -378,7 +378,7 @@ export default class BridgeContracts extends AbstractBridgeDeploy<config.EvmBrid
       const tx =
         await this.bridgeRouterContract.populateTransaction.enrollRemoteRouter(
           remoteDomain,
-          utils.canonizeId(remoteRouter)
+          utils.canonizeId(remoteRouter),
         );
       // safe as populateTransaction always sets `to`
       batch.push(this.domainNumber, tx as Call);
@@ -469,12 +469,13 @@ export default class BridgeContracts extends AbstractBridgeDeploy<config.EvmBrid
             custom.name,
             custom.symbol,
             custom.decimals,
+            this.overrides,
           )
         ).wait(this.confirmations);
 
         // transfer ownership to the bridge router
         await (
-          await tokenProxy.transferOwnership(bridge)
+          await tokenProxy.transferOwnership(bridge, this.overrides)
         ).wait(this.confirmations);
 
         // add custom to data
@@ -501,7 +502,7 @@ export default class BridgeContracts extends AbstractBridgeDeploy<config.EvmBrid
             await this.tokenRegistryContract.populateTransaction.enrollCustom(
               custom.token.domain,
               utils.canonizeId(custom.token.id),
-              proxy.address
+              proxy.address,
             ),
           ];
         }
@@ -533,7 +534,10 @@ export default class BridgeContracts extends AbstractBridgeDeploy<config.EvmBrid
     const registryOwner = await this.tokenRegistryContract.owner();
     if (utils.equalIds(registryOwner, deployer)) {
       log(`transfer token registry ownership on ${name}`);
-      const tx = await this.tokenRegistryContract.transferOwnership(this.bridgeRouterContract.address, this.overrides);
+      const tx = await this.tokenRegistryContract.transferOwnership(
+        this.bridgeRouterContract.address,
+        this.overrides,
+      );
       await tx.wait(this.confirmations);
     }
 
@@ -541,7 +545,10 @@ export default class BridgeContracts extends AbstractBridgeDeploy<config.EvmBrid
     const bridgeOwner = await this.bridgeRouterContract.owner();
     if (utils.equalIds(bridgeOwner, deployer)) {
       log(`transfer bridge router ownership on ${name}`);
-      const tx = await this.bridgeRouterContract.transferOwnership(governance, this.overrides);
+      const tx = await this.bridgeRouterContract.transferOwnership(
+        governance,
+        this.overrides,
+      );
       await tx.wait(this.confirmations);
     }
   }
@@ -605,8 +612,9 @@ export default class BridgeContracts extends AbstractBridgeDeploy<config.EvmBrid
     assertBeaconProxy(this.data.tokenRegistry, 'TokenRegistry');
     // owner
     const tokenRegistryOwner = await this.tokenRegistryContract.owner();
-    expect(utils.equalIds(tokenRegistryOwner, this.bridgeRouterContract.address)).to
-        .be.true;
+    expect(
+      utils.equalIds(tokenRegistryOwner, this.bridgeRouterContract.address),
+    ).to.be.true;
 
     // xAppConnectionManager
     const xAppAddress =

--- a/packages/deploy/src/core/CoreContracts.ts
+++ b/packages/deploy/src/core/CoreContracts.ts
@@ -352,10 +352,8 @@ export default class EvmCoreDeploy extends AbstractCoreDeploy<config.EvmCoreCont
     const proxy = await this.newProxy(home.address, initData);
     this._data.home = proxy;
 
-    await Promise.all([
-      this.xAppConnectionManager.setHome(proxy.proxy),
-      this.updaterManager.setHome(proxy.proxy),
-    ]);
+    await this.xAppConnectionManager.setHome(proxy.proxy);
+    await this.updaterManager.setHome(proxy.proxy);
 
     this.context.pushVerification(name, {
       name: 'Home',
@@ -584,19 +582,16 @@ export default class EvmCoreDeploy extends AbstractCoreDeploy<config.EvmCoreCont
       return batch;
     }
 
-    // If we can use deployer ownership
-    const txns = await Promise.all(
-      watchersToEnroll.map((watcher) =>
-        this.xAppConnectionManager.setWatcherPermission(
-          utils.evmId(watcher),
-          remoteConfig.domain,
-          true,
-          this.overrides,
-        ),
-      ),
-    );
-    await Promise.race(txns.map((tx) => tx.wait(this.confirmations)));
-    return;
+    // If we can use deployer ownership, send the transaction directly
+    for (const watcher of watchersToEnroll) {
+      const tx = await this.xAppConnectionManager.setWatcherPermission(
+        utils.evmId(watcher),
+        remoteConfig.domain,
+        true,
+        this.overrides,
+      );
+      await tx.wait(this.confirmations);
+    }
   }
 
   async enrollGovernanceRouter(
@@ -642,11 +637,11 @@ export default class EvmCoreDeploy extends AbstractCoreDeploy<config.EvmCoreCont
 
   async enrollRemote(remoteDomain: string | number): Promise<CallBatch> {
     await this.deployUnenrolledReplica(remoteDomain);
-    const batches = await Promise.all([
-      this.enrollReplica(remoteDomain),
-      this.enrollWatchers(remoteDomain),
-      this.enrollGovernanceRouter(remoteDomain),
-    ]);
+
+    const batches = [];
+    batches.push(await this.enrollReplica(remoteDomain));
+    batches.push(await this.enrollWatchers(remoteDomain));
+    batches.push(await this.enrollGovernanceRouter(remoteDomain));
 
     return CallBatch.flatten(this.context.asNomadContext, batches);
   }
@@ -665,21 +660,14 @@ export default class EvmCoreDeploy extends AbstractCoreDeploy<config.EvmCoreCont
     ];
 
     // conditional to avoid erroring
-    const txns = await Promise.all(
-      contracts.map(async (contract) => {
-        const owner = await contract.owner();
-        if (utils.equalIds(owner, deployer)) {
-          log(`transfer core ownership on ${local}`);
-          return await contract.transferOwnership(governance, this.overrides);
-        }
-      }),
-    );
-
-    await Promise.race(
-      txns.map(async (tx) => {
-        if (tx) await tx.wait();
-      }),
-    );
+    for (const contract of contracts) {
+      const owner = await contract.owner();
+      if (utils.equalIds(owner, deployer)) {
+        log(`transfer core ownership on ${local}`);
+        const tx = await contract.transferOwnership(governance, this.overrides);
+        await tx.wait(this.confirmations);
+      }
+    }
   }
 
   /// Transfers governorship on this core to the appropriate remote domain or

--- a/packages/deploy/src/core/CoreContracts.ts
+++ b/packages/deploy/src/core/CoreContracts.ts
@@ -352,8 +352,8 @@ export default class EvmCoreDeploy extends AbstractCoreDeploy<config.EvmCoreCont
     const proxy = await this.newProxy(home.address, initData);
     this._data.home = proxy;
 
-    await this.xAppConnectionManager.setHome(proxy.proxy);
-    await this.updaterManager.setHome(proxy.proxy);
+    await this.xAppConnectionManager.setHome(proxy.proxy, this.overrides);
+    await this.updaterManager.setHome(proxy.proxy, this.overrides);
 
     this.context.pushVerification(name, {
       name: 'Home',
@@ -513,7 +513,6 @@ export default class EvmCoreDeploy extends AbstractCoreDeploy<config.EvmCoreCont
         await this.xAppConnectionManager.populateTransaction.ownerEnrollReplica(
           replica,
           remoteConfig.domain,
-          this.overrides,
         );
       const batch = CallBatch.fromContext(this.context.asNomadContext);
       // safe as populateTransaction always sets `to`
@@ -571,7 +570,6 @@ export default class EvmCoreDeploy extends AbstractCoreDeploy<config.EvmCoreCont
             utils.evmId(watcher),
             remoteConfig.domain,
             true,
-            this.overrides,
           );
         }),
       );
@@ -630,6 +628,7 @@ export default class EvmCoreDeploy extends AbstractCoreDeploy<config.EvmCoreCont
     const tx = await this.governanceRouter.setRouterLocal(
       remoteConfig.domain,
       utils.canonizeId(remoteCore.governanceRouter.address),
+      this.overrides,
     );
     await tx.wait(this.confirmations);
     return;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below. Bug fixes and new features should include tests.

New contributors should read the contributors guide:
https://github.com/nomad-xyz/monorepo/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building
the documentation.
-->
## RFC
https://app.clickup.com/14205595/v/dc/dhgmv-10741/dhgmv-9921

## Motivation

The current deploy script has high concurrency, submitting many transactions at a time for a single chain. There are two challenges with this: 
1. For lower-quality chains, there are often nonce-related errors thrown (despite using NonceManager) - the mempool / nodes for the chain often don't handle this gracefully
2. For lower-quality RPCs, the number of concurrent requests can often cause rate limiting 

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Add a boolean flag to the deploy script which introduces the option to reduce intra-chain concurrency. 
If this flag is set to true, the transactions submitted for each chain will be submitted sequentially, while concurrency will be maintained where possible between chains. 
Example: all transactions to Rinkeby will be awaited one-by-one. Transactions to Goerli can be executed at the same time as transactions to Rinkeby.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Updated Documentation
- [ ] Updated CHANGELOG.md for the appropriate package
