### PR TITLE
feature: convenience getter for s3 filename

### DIFF
--- a/packages/sdk/src/messages/NomadMessage.ts
+++ b/packages/sdk/src/messages/NomadMessage.ts
@@ -492,6 +492,21 @@ export class NomadMessage<T extends NomadContext> {
   }
 
   /**
+   * The name of the domain from which the message was sent
+   */
+  get originName(): string {
+    return this.context.resolveDomainName(this.origin);
+  }
+
+  /**
+   * Get the name of this file in the s3 bucket
+   */
+  get s3Name(): string {
+    const index = this.leafIndex.toNumber();
+    return `${this.originName}_${index}.json`;
+  }
+
+  /**
    * The identifier for the sender of this message
    */
   get sender(): string {


### PR DESCRIPTION
## Motivation

We want to use the message object to check for s3 proofs. 

## Solution

Add a getter for the filename

Potential TODOs:
- add an async function to attempt to retrieve the proof? cc @ErinHales @Imti 
- add the bucket URI stem to the config format? cc @ltchang2019 

## PR Checklist

- [ ] Added Tests
- [ ] Updated Documentation
- [ ] Updated CHANGELOG.md for the appropriate package
