### PR TITLE
Prestwich/s3 uri extensions

### DIFF
--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 ### Unreleased
 
+- add s3 name and URI getters
+- add getProof async method for retrieving proofs from s3
+
 ### 2.0.0-rc.13
+
 - fix: make paginated event querying use the new config layout
 - chore: bump configuration to v0.1.0-rc.18
 

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -31,7 +31,7 @@
     "coverage": "nyc --reporter=html ts-mocha ./tests/*.ts"
   },
   "dependencies": {
-    "@nomad-xyz/configuration": "^0.1.0-rc.18",
+    "@nomad-xyz/configuration": "^0.1.0-rc.20",
     "@nomad-xyz/contracts-core": "workspace:^",
     "@nomad-xyz/multi-provider": "workspace:^",
     "ethers": "^5.0.0"

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -34,6 +34,7 @@
     "@nomad-xyz/configuration": "^0.1.0-rc.20",
     "@nomad-xyz/contracts-core": "workspace:^",
     "@nomad-xyz/multi-provider": "workspace:^",
+    "axios": "^0.27.2",
     "ethers": "^5.0.0"
   },
   "devDependencies": {

--- a/packages/sdk/src/NomadContext.ts
+++ b/packages/sdk/src/NomadContext.ts
@@ -9,16 +9,49 @@ import { NomadMessage } from './messages/NomadMessage';
 
 export type Address = string;
 
-type Path = [BytesLike, BytesLike, BytesLike, BytesLike, BytesLike, BytesLike, BytesLike, BytesLike, BytesLike, BytesLike, BytesLike, BytesLike, BytesLike, BytesLike, BytesLike, BytesLike, BytesLike, BytesLike, BytesLike, BytesLike, BytesLike, BytesLike, BytesLike, BytesLike, BytesLike, BytesLike, BytesLike, BytesLike, BytesLike, BytesLike, BytesLike, BytesLike];
+type Path = [
+  BytesLike,
+  BytesLike,
+  BytesLike,
+  BytesLike,
+  BytesLike,
+  BytesLike,
+  BytesLike,
+  BytesLike,
+  BytesLike,
+  BytesLike,
+  BytesLike,
+  BytesLike,
+  BytesLike,
+  BytesLike,
+  BytesLike,
+  BytesLike,
+  BytesLike,
+  BytesLike,
+  BytesLike,
+  BytesLike,
+  BytesLike,
+  BytesLike,
+  BytesLike,
+  BytesLike,
+  BytesLike,
+  BytesLike,
+  BytesLike,
+  BytesLike,
+  BytesLike,
+  BytesLike,
+  BytesLike,
+  BytesLike,
+];
 
-type MessageProof = {
+export type MessageProof = {
   message: BytesLike;
   proof: {
     leaf: BytesLike;
     index: number;
     path: Path;
-  }
-}
+  };
+};
 
 /**
  * The NomadContext manages connections to Nomad core and Bridge contracts.
@@ -193,7 +226,7 @@ export class NomadContext extends MultiProvider<config.Domain> {
   /**
    * Proves and Processes a transaction on the destination chain. This is subsidize and
    * automatic on non-Ethereum destinations
-   * 
+   *
    * @dev Ensure that a transaction is ready to be processed. You should ensure the following
    * criteria have been met prior to calling this function:
    *  1. The tx has been relayed (has status of 2):
@@ -204,7 +237,9 @@ export class NomadContext extends MultiProvider<config.Domain> {
    * @param message NomadMessage
    * @returns The Contract Transaction receipt
    */
-  async process(message: NomadMessage<NomadContext>): Promise<ContractTransaction>{
+  async process(
+    message: NomadMessage<NomadContext>,
+  ): Promise<ContractTransaction> {
     const s3URL = `https://nomadxyz-${this.environment}-proofs.s3.us-west-2.amazonaws.com/`;
 
     const originNetwork = this.resolveDomainName(message.origin);
@@ -220,7 +255,7 @@ export class NomadContext extends MultiProvider<config.Domain> {
     return replica.proveAndProcess(
       data.message,
       data.proof.path,
-      data.proof.index
+      data.proof.index,
     );
   }
 

--- a/packages/sdk/src/messages/NomadMessage.ts
+++ b/packages/sdk/src/messages/NomadMessage.ts
@@ -503,7 +503,18 @@ export class NomadMessage<T extends NomadContext> {
    */
   get s3Name(): string {
     const index = this.leafIndex.toNumber();
-    return `${this.originName}_${index}.json`;
+    return `${this.originName}_${index}`;
+  }
+
+  /**
+   * Get the URI for the proof in S3
+   */
+  get s3Uri(): string | undefined {
+    const s3 = this.context.conf.s3;
+    if (!s3) return;
+    const { bucket, region } = s3;
+    const root = `https://${bucket}.s3.${region}.amazonaws.com`;
+    return `${root}/${this.s3Name}`;
   }
 
   /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -1666,6 +1666,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@nomad-xyz/configuration@npm:^0.1.0-rc.20":
+  version: 0.1.0-rc.20
+  resolution: "@nomad-xyz/configuration@npm:0.1.0-rc.20"
+  checksum: df1852233cbd55a6605443d03f40530a00163f80dc7b377a249871ffafb620a77f8d204885c2a9905e5d4d91e4229e99da56549c17add45bb3d7c5e7dbe8e663
+  languageName: node
+  linkType: hard
+
 "@nomad-xyz/contract-interfaces@npm:1.1.1":
   version: 1.1.1
   resolution: "@nomad-xyz/contract-interfaces@npm:1.1.1"
@@ -1976,7 +1983,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@nomad-xyz/sdk@workspace:packages/sdk"
   dependencies:
-    "@nomad-xyz/configuration": ^0.1.0-rc.18
+    "@nomad-xyz/configuration": ^0.1.0-rc.20
     "@nomad-xyz/contracts-core": "workspace:^"
     "@nomad-xyz/local-environment": "workspace:^"
     "@nomad-xyz/multi-provider": "workspace:^"
@@ -7396,7 +7403,7 @@ __metadata:
   dependencies:
     bn.js: ^4.11.8
     ethereumjs-util: ^6.0.0
-  checksum: ae074be0bb012857ab5d3ae644d1163b908a48dd724b7d2567cfde309dc72222d460438f2411936a70dc949dc604ce1ef7118f7273bd525815579143c907e336
+  checksum: 03127d09960e5f8a44167463faf25b2894db2f746376dbb8195b789ed11762f93db9c574eaa7c498c400063508e9dfc1c80de2edf5f0e1406b25c87d860ff2f1
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1992,6 +1992,7 @@ __metadata:
     "@types/node": ^16.9.1
     "@typescript-eslint/eslint-plugin": ^5.20.0
     "@typescript-eslint/parser": ^5.20.0
+    axios: ^0.27.2
     dotenv: ^10.0.0
     eslint: ^7.32.0
     eslint-config-prettier: ^8.3.0
@@ -3745,6 +3746,16 @@ __metadata:
   dependencies:
     follow-redirects: ^1.14.8
   checksum: d9eb58ff4bc0b36a04783fc9ff760e9245c829a5a1052ee7ca6013410d427036b1d10d04e7380c02f3508c5eaf3485b1ae67bd2adbfec3683704745c8d7a6e1a
+  languageName: node
+  linkType: hard
+
+"axios@npm:^0.27.2":
+  version: 0.27.2
+  resolution: "axios@npm:0.27.2"
+  dependencies:
+    follow-redirects: ^1.14.9
+    form-data: ^4.0.0
+  checksum: 38cb7540465fe8c4102850c4368053c21683af85c5fdf0ea619f9628abbcb59415d1e22ebc8a6390d2bbc9b58a9806c874f139767389c862ec9b772235f06854
   languageName: node
   linkType: hard
 
@@ -8306,6 +8317,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"follow-redirects@npm:^1.14.9":
+  version: 1.15.0
+  resolution: "follow-redirects@npm:1.15.0"
+  peerDependenciesMeta:
+    debug:
+      optional: true
+  checksum: eaec81c3e0ae57aae2422e38ad3539d0e7279b3a63f9681eeea319bb683dea67502c4e097136b8ce9721542b4e236e092b6b49e34e326cdd7733c274f0a3f378
+  languageName: node
+  linkType: hard
+
 "font-atlas@npm:^2.1.0":
   version: 2.1.0
   resolution: "font-atlas@npm:2.1.0"
@@ -8383,6 +8404,17 @@ __metadata:
     combined-stream: ^1.0.8
     mime-types: ^2.1.12
   checksum: b019e8d35c8afc14a2bd8a7a92fa4f525a4726b6d5a9740e8d2623c30e308fbb58dc8469f90415a856698933c8479b01646a9dff33c87cc4e76d72aedbbf860d
+  languageName: node
+  linkType: hard
+
+"form-data@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "form-data@npm:4.0.0"
+  dependencies:
+    asynckit: ^0.4.0
+    combined-stream: ^1.0.8
+    mime-types: ^2.1.12
+  checksum: 01135bf8675f9d5c61ff18e2e2932f719ca4de964e3be90ef4c36aacfc7b9cb2fceb5eca0b7e0190e3383fe51c5b37f4cb80b62ca06a99aaabfcfd6ac7c9328c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Builds off #273 

## Motivation

Provide a simple sane way to retrieve proofs for a message from s3.

## Solution

- Add an s3uri getter, 
- Add a getProof() async method
- Add sanity checking on s3 response
- fix filename bug (unnecessary `".json"`)

## PR Checklist

- [ ] Added Tests
- [x] Updated Documentation
- [x] Updated CHANGELOG.md for the appropriate package
