### PR TITLE
add: prepare sends

### DIFF
--- a/packages/sdk-bridge/CHANGELOG.md
+++ b/packages/sdk-bridge/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### Unreleased
 
+### 1.0.0-rc.14
+
+- add: prepareSend, prepareSendNative
+
 ### 1.0.0-rc.13
 
 - fix: hard code gas limit for sendNative

--- a/packages/sdk-bridge/package.json
+++ b/packages/sdk-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nomad-xyz/sdk-bridge",
-  "version": "1.0.0-rc.13",
+  "version": "1.0.0-rc.14",
   "description": "Nomad bridge SDK",
   "keywords": [
     "nomad",

--- a/packages/sdk-bridge/src/BridgeContext.ts
+++ b/packages/sdk-bridge/src/BridgeContext.ts
@@ -281,7 +281,7 @@ export class BridgeContext extends NomadContext {
     );
     tx.gasLimit = BigNumber.from(350000);
 
-    return tx
+    return tx;
   }
 
   /**

--- a/packages/sdk-bridge/src/BridgeContext.ts
+++ b/packages/sdk-bridge/src/BridgeContext.ts
@@ -232,7 +232,7 @@ export class BridgeContext extends NomadContext {
    *          transfer
    * @throws On missing signers, missing tokens, tx issues, etc.
    */
-  async send(
+  async prepareSend(
     from: string | number,
     to: string | number,
     token: TokenIdentifier,
@@ -240,7 +240,7 @@ export class BridgeContext extends NomadContext {
     recipient: Address,
     enableFast = false,
     overrides: ethers.Overrides = {},
-  ): Promise<TransferMessage> {
+  ): Promise<ethers.PopulatedTransaction> {
     const fromDomain = this.resolveDomain(from);
 
     await this.checkHome(fromDomain);
@@ -280,6 +280,42 @@ export class BridgeContext extends NomadContext {
       overrides,
     );
     tx.gasLimit = BigNumber.from(350000);
+
+    return tx
+  }
+
+  /**
+   * Send tokens from one domain to another. Approves the bridge if necessary.
+   *
+   * @param from The domain to send from
+   * @param to The domain to send to
+   * @param token The canonical token to send (details from originating chain)
+   * @param amount The amount (in smallest unit) to send
+   * @param recipient The identifier to send to on the `to` domain
+   * @param enableFast TRUE to enable fast liquidity; FALSE to require no fast liquidity
+   * @param overrides Any tx overrides (e.g. gas price)
+   * @returns a {@link TransferMessage} object representing the in-flight
+   *          transfer
+   * @throws On missing signers, missing tokens, tx issues, etc.
+   */
+  async send(
+    from: string | number,
+    to: string | number,
+    token: TokenIdentifier,
+    amount: BigNumberish,
+    recipient: Address,
+    enableFast = false,
+    overrides: ethers.Overrides = {},
+  ): Promise<TransferMessage> {
+    const tx = await this.prepareSend(
+      from,
+      to,
+      token,
+      amount,
+      recipient,
+      enableFast,
+      overrides,
+    );
     const dispatch = await this.mustGetSigner(from).sendTransaction(tx);
     const receipt = await dispatch.wait();
 
@@ -305,14 +341,14 @@ export class BridgeContext extends NomadContext {
    *          transfer
    * @throws On missing signers, tx issues, etc.
    */
-  async sendNative(
+  async prepareSendNative(
     from: string | number,
     to: string | number,
     amount: BigNumberish,
     recipient: Address,
     enableFast = false,
     overrides: ethers.PayableOverrides = {},
-  ): Promise<TransferMessage> {
+  ): Promise<ethers.PopulatedTransaction> {
     const fromDomain = this.resolveDomain(from);
 
     await this.checkHome(fromDomain);
@@ -339,6 +375,40 @@ export class BridgeContext extends NomadContext {
       overrides,
     );
     tx.gasLimit = BigNumber.from(350000);
+    return tx;
+  }
+
+  /**
+   * Send a chain's native asset from one chain to another using the
+   * `EthHelper` contract.
+   *
+   * @param from The domain to send from
+   * @param to The domain to send to
+   * @param amount The amount (in smallest unit) to send
+   * @param recipient The identifier to send to on the `to` domain
+   * @param enableFast TRUE to enable fast liquidity; FALSE to require no fast liquidity
+   * @param overrides Any tx overrides (e.g. gas price)
+   * @returns a {@link TransferMessage} object representing the in-flight
+   *          transfer
+   * @throws On missing signers, tx issues, etc.
+   */
+  async sendNative(
+    from: string | number,
+    to: string | number,
+    amount: BigNumberish,
+    recipient: Address,
+    enableFast = false,
+    overrides: ethers.PayableOverrides = {},
+  ): Promise<TransferMessage> {
+    const tx = await this.prepareSendNative(
+      from,
+      to,
+      amount,
+      recipient,
+      enableFast,
+      overrides,
+    );
+
     const dispatch = await this.mustGetSigner(from).sendTransaction(tx);
     const receipt = await dispatch.wait();
 


### PR DESCRIPTION
Expose the unsigned transaction, for allowing bridging using fireblocks wallet

## Motivation

Enable partners to bridge using fireblocks

## Solution

Add `prepareSend` and `prepareSendNative` that expose the unsigned tx

## PR Checklist

- [x] Added Tests (no additional code, just splits up existing functions)
- [x] Updated Documentation
- [x] Updated CHANGELOG.md for the appropriate package
