### PR TITLE
fix: prevent messages rendered invalid during recovery from eventually being processed

### DIFF
--- a/packages/contracts-core/contracts/Replica.sol
+++ b/packages/contracts-core/contracts/Replica.sol
@@ -280,7 +280,7 @@ contract Replica is Version0, NomadBase {
         uint256 _index
     ) public returns (bool) {
         // ensure that message has not been proven or processed
-        require(messages[_leaf] == bytes32(uint256(0)), "!MessageStatus.None");
+        require(messages[_leaf] == bytes32(0), "!MessageStatus.None");
         // calculate the expected root based on the proof
         bytes32 _calculatedRoot = MerkleLib.branchRoot(_leaf, _proof, _index);
         // if the root is valid, change status to Proven

--- a/packages/contracts-core/contracts/test/TestReplica.sol
+++ b/packages/contracts-core/contracts/test/TestReplica.sol
@@ -18,7 +18,7 @@ contract TestReplica is Replica {
 
     function setMessagePending(bytes memory _message) external {
         bytes29 _m = _message.ref(0);
-        messages[_m.keccak()] = MessageStatus.Proven;
+        messages[_m.keccak()] = bytes32(uint256(1));
     }
 
     function setCommittedRoot(bytes32 _newRoot) external {

--- a/packages/contracts-core/contracts/test/TestReplica.sol
+++ b/packages/contracts-core/contracts/test/TestReplica.sol
@@ -18,7 +18,7 @@ contract TestReplica is Replica {
 
     function setMessagePending(bytes memory _message) external {
         bytes29 _m = _message.ref(0);
-        messages[_m.keccak()] = bytes32(uint256(1));
+        messages[_m.keccak()] = LEGACY_STATUS_PROVEN;
     }
 
     function setCommittedRoot(bytes32 _newRoot) external {

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Unreleased
 
+- fix: update replica message status getter for new replica mapping
+
 ### 2.0.0-rc.17
 
 - chore: bump configuration to v0.1.0-rc.23

--- a/packages/sdk/src/messages/NomadMessage.ts
+++ b/packages/sdk/src/messages/NomadMessage.ts
@@ -25,6 +25,7 @@ import { queryAnnotatedEvents } from '..';
 import { keccak256 } from 'ethers/lib/utils';
 import { MessageProof } from '../NomadContext';
 import axios from 'axios';
+import { ethers } from 'ethers';
 
 export type ParsedMessage = {
   from: number;
@@ -447,7 +448,12 @@ export class NomadMessage<T extends NomadContext> {
    * status of the message.
    */
   async replicaStatus(): Promise<ReplicaMessageStatus> {
-    return this.replica.messages(this.leaf);
+    const root = await this.replica.messages(this.leaf);
+    if (root === ethers.constants.HashZero) return ReplicaMessageStatus.None;
+    if (root === `0x${'00'.repeat(31)}02`)
+      return ReplicaMessageStatus.Processed;
+
+    return ReplicaMessageStatus.Proven;
   }
 
   /**

--- a/packages/sdk/src/messages/NomadMessage.ts
+++ b/packages/sdk/src/messages/NomadMessage.ts
@@ -448,9 +448,12 @@ export class NomadMessage<T extends NomadContext> {
    * status of the message.
    */
   async replicaStatus(): Promise<ReplicaMessageStatus> {
-    const root = await this.replica.messages(this.leaf);
-    if (root === ethers.constants.HashZero) return ReplicaMessageStatus.None;
-    if (root === `0x${'00'.repeat(31)}02`)
+    // backwards compatibility. Older replica versions returned a number,
+    // newer versions return a hash
+    const root = (await this.replica.messages(this.leaf)) as string | number;
+    if (root === ethers.constants.HashZero || root === 0)
+      return ReplicaMessageStatus.None;
+    if (root === `0x${'00'.repeat(31)}02` || root === 2)
       return ReplicaMessageStatus.Processed;
 
     return ReplicaMessageStatus.Proven;


### PR DESCRIPTION
## Motivation

Currently if a message is proven under a fraudulent root, it can eventually be processed even if the root is deleted from the confirmAt mapping by governance action. This means that the governance would need to clean each fraudulent message individually

## Solution

- instead of storing a messagestatus enum, prove stores the root that was calculated for the proof
- process checks that the root is acceptable again before dispatch

- for backwards compatibility `MessageStatus.Proven` is hardcoded as an acceptable root.

- we now allow re-proving a message under a new root. This ensures that VALID messages proved under an INVALID root can be processed after fraud recovery

- This SHOULD NOT break storage as we simply change the semantics of a mapping, rather than the storage layout
- This WILL require mainnet fork testing to ensure that it doesn't break storage in unexpected ways

## PR Checklist

- [ ] Added Tests
- [ ] Updated Documentation
- [ ] Updated CHANGELOG.md for the appropriate package
