### PR TITLE
[QSP-8, QSP-10, QSP-11] deprecate fast liquidity send path

### DIFF
--- a/packages/contracts-bridge/contracts/BridgeMessage.sol
+++ b/packages/contracts-bridge/contracts/BridgeMessage.sol
@@ -134,19 +134,17 @@ library BridgeMessage {
      * @notice Formats Transfer
      * @param _to The recipient address as bytes32
      * @param _amnt The transfer amount
-     * @param _enableFast True to format FastTransfer, False to format regular Transfer
+     * @param _detailsHash The hash of the token name, symbol, and decimals
      * @return
      */
     function formatTransfer(
         bytes32 _to,
         uint256 _amnt,
-        bytes32 _detailsHash,
-        bool _enableFast
+        bytes32 _detailsHash
     ) internal pure returns (bytes29) {
-        Types _type = _enableFast ? Types.FastTransfer : Types.Transfer;
         return
-            abi.encodePacked(_type, _to, _amnt, _detailsHash).ref(0).castTo(
-                uint40(_type)
+            abi.encodePacked(Types.Transfer, _to, _amnt, _detailsHash).ref(0).castTo(
+                uint40(Types.Transfer)
             );
     }
 

--- a/packages/contracts-bridge/contracts/BridgeRouter.sol
+++ b/packages/contracts-bridge/contracts/BridgeRouter.sol
@@ -135,7 +135,8 @@ contract BridgeRouter is Version0, Router {
         address _token,
         uint256 _amount,
         uint32 _destination,
-        bytes32 _recipient
+        bytes32 _recipient,
+        bool /*_enableFast - deprecated field, left argument for backwards compatibility */
     ) public {
         require(_amount > 0, "!amnt");
         require(_recipient != bytes32(0), "!recip");
@@ -185,21 +186,6 @@ contract BridgeRouter is Version0, Router {
             _amount,
             false
         );
-    }
-
-    /**
-     * @dev For backwards compatibility after
-     * deprecating fast liquidity path.
-     * Simply calls send & omits _enableFast boolean.
-     */
-    function send(
-        address _token,
-        uint256 _amount,
-        uint32 _destination,
-        bytes32 _recipient,
-        bool /*_enableFast*/
-    ) external {
-        send(_token, _amount, _destination, _recipient);
     }
 
     // ======== External: Custom Tokens =========

--- a/packages/contracts-bridge/contracts/BridgeRouter.sol
+++ b/packages/contracts-bridge/contracts/BridgeRouter.sol
@@ -137,7 +137,7 @@ contract BridgeRouter is Version0, Router {
         uint32 _destination,
         bytes32 _recipient,
         bool /*_enableFast - deprecated field, left argument for backwards compatibility */
-    ) public {
+    ) external {
         require(_amount > 0, "!amnt");
         require(_recipient != bytes32(0), "!recip");
         // get remote BridgeRouter address; revert if not found

--- a/packages/contracts-bridge/contracts/test/TestBridgeMessage.sol
+++ b/packages/contracts-bridge/contracts/test/TestBridgeMessage.sol
@@ -92,12 +92,11 @@ contract TestBridgeMessage {
     function testFormatTransfer(
         bytes32 _to,
         uint256 _amnt,
-        bytes32 _detailsHash,
-        bool _enableFast
+        bytes32 _detailsHash
     ) external view returns (bytes memory) {
         return
             BridgeMessage
-                .formatTransfer(_to, _amnt, _detailsHash, _enableFast)
+                .formatTransfer(_to, _amnt, _detailsHash)
                 .clone();
     }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below. Bug fixes and new features should include tests.

New contributors should read the contributors guide:
https://github.com/nomad-xyz/monorepo/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building
the documentation.
-->

## Motivation
Fast liquidity feature was mostly a proof of concept, which was not in use in production.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
We are choosing to deprecate it.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Updated Documentation
- [ ] Updated CHANGELOG.md for the appropriate package
