### PR TITLE
[QSP-4] reverse order of search in queue.contains

### DIFF
--- a/packages/contracts-core/contracts/libs/Queue.sol
+++ b/packages/contracts-core/contracts/libs/Queue.sol
@@ -121,7 +121,7 @@ library QueueLib {
         view
         returns (bool)
     {
-        for (uint256 i = _q.first; i <= _q.last; i++) {
+        for (uint256 i = _q.last; i >= _q.first; i--) {
             if (_q.queue[i] == _item) {
                 return true;
             }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below. Bug fixes and new features should include tests.

New contributors should read the contributors guide:
https://github.com/nomad-xyz/monorepo/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building
the documentation.
-->

## Motivation
The `queue.contain` on Home scans for an item from first to last. In the case of a very long queue, when looking for an item at the end of the queue, the transaction could run out of gas. 
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Search the queue from last to first instead. The Updater signs recent roots, so this mitigates the likelihood that the queue is too long to find the root.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Updated Documentation
- [ ] Updated CHANGELOG.md for the appropriate package
