### PR TITLE
[QSP-2] remove FAILED state from Replica

### DIFF
--- a/packages/contracts-core/contracts/Home.sol
+++ b/packages/contracts-core/contracts/Home.sol
@@ -76,6 +76,21 @@ contract Home is Version0, QueueManager, MerkleTreeManager, NomadBase {
     event ImproperUpdate(bytes32 oldRoot, bytes32 newRoot, bytes signature);
 
     /**
+    * @notice Emitted when proof of a double update is submitted,
+     * which sets the contract to FAILED state
+     * @param oldRoot Old root shared between two conflicting updates
+     * @param newRoot Array containing two conflicting new roots
+     * @param signature Signature on `oldRoot` and `newRoot`[0]
+     * @param signature2 Signature on `oldRoot` and `newRoot`[1]
+     */
+    event DoubleUpdate(
+        bytes32 oldRoot,
+        bytes32[2] newRoot,
+        bytes signature,
+        bytes signature2
+    );
+
+    /**
      * @notice Emitted when the Updater is slashed
      * (should be paired with ImproperUpdater or DoubleUpdate event)
      * @param updater The address of the updater
@@ -109,6 +124,14 @@ contract Home is Version0, QueueManager, MerkleTreeManager, NomadBase {
      */
     modifier onlyUpdaterManager() {
         require(msg.sender == address(updaterManager), "!updaterManager");
+        _;
+    }
+
+    /**
+    * @notice Ensures that contract state != FAILED when the function is called
+     */
+    modifier notFailed() {
+        require(state != States.Failed, "failed state");
         _;
     }
 
@@ -225,6 +248,33 @@ contract Home is Version0, QueueManager, MerkleTreeManager, NomadBase {
         }
     }
 
+    /**
+    * @notice Called by external agent. Checks that signatures on two sets of
+     * roots are valid and that the new roots conflict with each other. If both
+     * cases hold true, the contract is failed and a `DoubleUpdate` event is
+     * emitted.
+     * @dev When `fail()` is called on Home, updater is slashed.
+     * @param _oldRoot Old root shared between two conflicting updates
+     * @param _newRoot Array containing two conflicting new roots
+     * @param _signature Signature on `_oldRoot` and `_newRoot`[0]
+     * @param _signature2 Signature on `_oldRoot` and `_newRoot`[1]
+     */
+    function doubleUpdate(
+        bytes32 _oldRoot,
+        bytes32[2] calldata _newRoot,
+        bytes calldata _signature,
+        bytes calldata _signature2
+    ) external notFailed {
+        if (
+            NomadBase._isUpdaterSignature(_oldRoot, _newRoot[0], _signature) &&
+            NomadBase._isUpdaterSignature(_oldRoot, _newRoot[1], _signature2) &&
+            _newRoot[0] != _newRoot[1]
+        ) {
+            _fail();
+            emit DoubleUpdate(_oldRoot, _newRoot, _signature, _signature2);
+        }
+    }
+
     // ============ Public Functions  ============
 
     /**
@@ -302,9 +352,9 @@ contract Home is Version0, QueueManager, MerkleTreeManager, NomadBase {
      * @notice Slash the Updater and set contract state to FAILED
      * @dev Called when fraud is proven (Improper Update or Double Update)
      */
-    function _fail() internal override {
+    function _fail() internal {
         // set contract to FAILED
-        _setFailed();
+        state = States.Failed;
         // slash Updater
         updaterManager.slashUpdater(msg.sender);
         emit UpdaterSlashed(updater, msg.sender);

--- a/packages/contracts-core/contracts/NomadBase.sol
+++ b/packages/contracts-core/contracts/NomadBase.sol
@@ -65,36 +65,11 @@ abstract contract NomadBase is Initializable, OwnableUpgradeable {
     );
 
     /**
-     * @notice Emitted when proof of a double update is submitted,
-     * which sets the contract to FAILED state
-     * @param oldRoot Old root shared between two conflicting updates
-     * @param newRoot Array containing two conflicting new roots
-     * @param signature Signature on `oldRoot` and `newRoot`[0]
-     * @param signature2 Signature on `oldRoot` and `newRoot`[1]
-     */
-    event DoubleUpdate(
-        bytes32 oldRoot,
-        bytes32[2] newRoot,
-        bytes signature,
-        bytes signature2
-    );
-
-    /**
      * @notice Emitted when Updater is rotated
      * @param oldUpdater The address of the old updater
      * @param newUpdater The address of the new updater
      */
     event NewUpdater(address oldUpdater, address newUpdater);
-
-    // ============ Modifiers ============
-
-    /**
-     * @notice Ensures that contract state != FAILED when the function is called
-     */
-    modifier notFailed() {
-        require(state != States.Failed, "failed state");
-        _;
-    }
 
     // ============ Constructor ============
 
@@ -108,35 +83,6 @@ abstract contract NomadBase is Initializable, OwnableUpgradeable {
         __Ownable_init();
         _setUpdater(_updater);
         state = States.Active;
-    }
-
-    // ============ External Functions ============
-
-    /**
-     * @notice Called by external agent. Checks that signatures on two sets of
-     * roots are valid and that the new roots conflict with each other. If both
-     * cases hold true, the contract is failed and a `DoubleUpdate` event is
-     * emitted.
-     * @dev When `fail()` is called on Home, updater is slashed.
-     * @param _oldRoot Old root shared between two conflicting updates
-     * @param _newRoot Array containing two conflicting new roots
-     * @param _signature Signature on `_oldRoot` and `_newRoot`[0]
-     * @param _signature2 Signature on `_oldRoot` and `_newRoot`[1]
-     */
-    function doubleUpdate(
-        bytes32 _oldRoot,
-        bytes32[2] calldata _newRoot,
-        bytes calldata _signature,
-        bytes calldata _signature2
-    ) external notFailed {
-        if (
-            NomadBase._isUpdaterSignature(_oldRoot, _newRoot[0], _signature) &&
-            NomadBase._isUpdaterSignature(_oldRoot, _newRoot[1], _signature2) &&
-            _newRoot[0] != _newRoot[1]
-        ) {
-            _fail();
-            emit DoubleUpdate(_oldRoot, _newRoot, _signature, _signature2);
-        }
     }
 
     // ============ Public Functions ============
@@ -159,22 +105,6 @@ abstract contract NomadBase is Initializable, OwnableUpgradeable {
     {
         return keccak256(abi.encodePacked(_homeDomain, "NOMAD"));
     }
-
-    /**
-     * @notice Set contract state to FAILED
-     * @dev Called when a valid fraud proof is submitted
-     */
-    function _setFailed() internal {
-        state = States.Failed;
-    }
-
-    /**
-     * @notice Moves the contract into failed state
-     * @dev Called when fraud is proven
-     * (Double Update is submitted on Home or Replica,
-     * or Improper Update is submitted on Home)
-     */
-    function _fail() internal virtual;
 
     /**
      * @notice Set the Updater

--- a/packages/contracts-core/contracts/Replica.sol
+++ b/packages/contracts-core/contracts/Replica.sol
@@ -64,8 +64,9 @@ contract Replica is Version0, NomadBase {
 
     /**
      * @notice Emitted when message is processed
-     * @param messageHash Hash of message that failed to process
-     * @param success TRUE if the call was executed successfully, FALSE if the call reverted
+     * @param messageHash Hash of message that was processed
+     * @param success TRUE if the call was executed successfully,
+     * FALSE if the call reverted or threw
      * @param returnData the return data from the external call
      */
     event Process(
@@ -139,7 +140,7 @@ contract Replica is Version0, NomadBase {
         bytes32 _oldRoot,
         bytes32 _newRoot,
         bytes memory _signature
-    ) external notFailed {
+    ) external {
         // ensure that update is building off the last submitted root
         require(_oldRoot == committedRoot, "not current update");
         // validate updater signature
@@ -344,14 +345,6 @@ contract Replica is Version0, NomadBase {
     }
 
     // ============ Internal Functions ============
-
-    /**
-     * @notice Moves the contract into failed state
-     * @dev Called when a Double Update is submitted
-     */
-    function _fail() internal override {
-        _setFailed();
-    }
 
     /// @notice Hook for potential future use
     // solhint-disable-next-line no-empty-blocks

--- a/packages/contracts-core/contracts/test/TestCommon.sol
+++ b/packages/contracts-core/contracts/test/TestCommon.sol
@@ -24,8 +24,4 @@ contract TestNomadBase is NomadBase {
     function homeDomainHash() public view override returns (bytes32) {
         return keccak256(abi.encodePacked(localDomain, "NOMAD"));
     }
-
-    function _fail() internal override {
-        _setFailed();
-    }
 }

--- a/packages/contracts-core/contracts/test/TestHome.sol
+++ b/packages/contracts-core/contracts/test/TestHome.sol
@@ -26,6 +26,6 @@ contract TestHome is Home {
     }
 
     function setFailed() public {
-        _setFailed();
+        state = States.Failed;
     }
 }

--- a/packages/contracts-core/contracts/test/TestReplica.sol
+++ b/packages/contracts-core/contracts/test/TestReplica.sol
@@ -14,10 +14,6 @@ contract TestReplica is Replica {
         uint256
     ) Replica(_localDomain, 850_000, 15_000) {} // solhint-disable-line no-empty-blocks
 
-    function setFailed() public {
-        _setFailed();
-    }
-
     function setRemoteDomain(uint32 _remoteDomain) external {
         remoteDomain = _remoteDomain;
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below. Bug fixes and new features should include tests.

New contributors should read the contributors guide:
https://github.com/nomad-xyz/monorepo/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building
the documentation.
-->

## Motivation
The xApp is in control of determining when to block a Replica contract. The security layer for blocking fraud is at the xAppConnectionManager, in the hands of the xApp.
Additionally, we are moving in a direction where the concept of a `doubleUpdate` - and therefore, proving Fraud on the Replica - are irrelevant.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Remove `doubleUpdate` proofs and ability to transition to FAILED state from the Replica.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Updated Documentation
- [ ] Updated CHANGELOG.md for the appropriate package
