### PR TITLE
[QSP-1] un-fail Home in setUpdater

### DIFF
--- a/packages/contracts-core/contracts/Home.sol
+++ b/packages/contracts-core/contracts/Home.sol
@@ -116,10 +116,14 @@ contract Home is Version0, QueueManager, MerkleTreeManager, NomadBase {
 
     /**
      * @notice Set a new Updater
+     * @dev To be set when rotating Updater after Fraud
      * @param _updater the new Updater
      */
     function setUpdater(address _updater) external onlyUpdaterManager {
         _setUpdater(_updater);
+        // set the Home state to Active
+        // now that Updater has been rotated
+        state = States.Active;
     }
 
     /**


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below. Bug fixes and new features should include tests.

New contributors should read the contributors guide:
https://github.com/nomad-xyz/monorepo/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building
the documentation.
-->

## Motivation
There must be a mechanism to transition the state from Failed to Active state in order to recover from proven Fraud.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Transition the Home from Failed to Active when the fraudulent Updater has been rotated for a new Updater.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Updated Documentation
- [ ] Updated CHANGELOG.md for the appropriate package
