### PR TITLE
[QSP-17] make renounceOwnership a no-op

### DIFF
--- a/packages/contracts-bridge/contracts/BridgeRouter.sol
+++ b/packages/contracts-bridge/contracts/BridgeRouter.sol
@@ -436,4 +436,13 @@ contract BridgeRouter is Version0, Router {
     {
         return (uint64(_origin) << 32) | _nonce;
     }
+
+    /**
+    * @dev should be impossible to renounce ownership;
+     * we override OpenZeppelin OwnableUpgradeable's
+     * implementation of renounceOwnership to make it a no-op
+     */
+    function renounceOwnership() public override onlyOwner {
+        // do nothing
+    }
 }

--- a/packages/contracts-bridge/contracts/BridgeToken.sol
+++ b/packages/contracts-bridge/contracts/BridgeToken.sol
@@ -242,4 +242,13 @@ contract BridgeToken is Version0, IBridgeToken, OwnableUpgradeable, ERC20 {
     {
         OwnableUpgradeable.transferOwnership(_newOwner);
     }
+
+    /**
+    * @dev should be impossible to renounce ownership;
+     * we override OpenZeppelin OwnableUpgradeable's
+     * implementation of renounceOwnership to make it a no-op
+     */
+    function renounceOwnership() public override onlyOwner {
+        // do nothing
+    }
 }

--- a/packages/contracts-bridge/contracts/TokenRegistry.sol
+++ b/packages/contracts-bridge/contracts/TokenRegistry.sol
@@ -400,4 +400,13 @@ contract TokenRegistry is Initializable, XAppConnectionClient, ITokenRegistry {
     {
         return XAppConnectionClient._localDomain();
     }
+
+    /**
+    * @dev should be impossible to renounce ownership;
+     * we override OpenZeppelin OwnableUpgradeable's
+     * implementation of renounceOwnership to make it a no-op
+     */
+    function renounceOwnership() public override onlyOwner {
+        // do nothing
+    }
 }

--- a/packages/contracts-core/contracts/NomadBase.sol
+++ b/packages/contracts-core/contracts/NomadBase.sol
@@ -204,4 +204,13 @@ abstract contract NomadBase is Initializable, OwnableUpgradeable {
         _digest = ECDSA.toEthSignedMessageHash(_digest);
         return (ECDSA.recover(_digest, _signature) == updater);
     }
+
+    /**
+     * @dev should be impossible to renounce ownership;
+     * we override OpenZeppelin OwnableUpgradeable's
+     * implementation of renounceOwnership to make it a no-op
+     */
+    function renounceOwnership() public override onlyOwner {
+        // do nothing
+    }
 }

--- a/packages/contracts-core/contracts/UpdaterManager.sol
+++ b/packages/contracts-core/contracts/UpdaterManager.sol
@@ -101,4 +101,13 @@ contract UpdaterManager is IUpdaterManager, Ownable {
     function updater() external view override returns (address) {
         return _updater;
     }
+
+    /**
+    * @dev should be impossible to renounce ownership;
+     * we override OpenZeppelin Ownable implementation
+     * of renounceOwnership to make it a no-op
+     */
+    function renounceOwnership() public override onlyOwner {
+        // do nothing
+    }
 }

--- a/packages/contracts-core/contracts/XAppConnectionManager.sol
+++ b/packages/contracts-core/contracts/XAppConnectionManager.sol
@@ -218,4 +218,13 @@ contract XAppConnectionManager is Ownable {
         _digest = ECDSA.toEthSignedMessageHash(_digest);
         return ECDSA.recover(_digest, _signature);
     }
+
+    /**
+    * @dev should be impossible to renounce ownership;
+     * we override OpenZeppelin Ownable implementation
+     * of renounceOwnership to make it a no-op
+     */
+    function renounceOwnership() public override onlyOwner {
+        // do nothing
+    }
 }

--- a/packages/contracts-core/contracts/governance/GovernanceRouter.sol
+++ b/packages/contracts-core/contracts/governance/GovernanceRouter.sol
@@ -547,6 +547,8 @@ contract GovernanceRouter is Version0, Initializable, IMessageRecipient {
         address _newGovernor,
         bool _isLocalGovernor
     ) internal {
+        // require that the new governor is not the zero address
+        require(_newGovernor != address(0), "cannot renounce governor");
         // require that the governor domain has a valid router
         if (!_isLocalGovernor) {
             _mustHaveRouter(_newDomain);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below. Bug fixes and new features should include tests.

New contributors should read the contributors guide:
https://github.com/nomad-xyz/monorepo/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building
the documentation.
-->

## Motivation
We do not want ownership of governable contracts to be renounced.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Make renounceOwnership a no-op

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Updated Documentation
- [ ] Updated CHANGELOG.md for the appropriate package
