### PR TITLE
[QSP-9, QSP-20] add bounds to optimisticSeconds

### DIFF
--- a/packages/contracts-core/contracts/Replica.sol
+++ b/packages/contracts-core/contracts/Replica.sol
@@ -134,8 +134,7 @@ contract Replica is Version0, NomadBase {
         committedRoot = _committedRoot;
         // pre-approve the committed root.
         confirmAt[_committedRoot] = 1;
-        optimisticSeconds = _optimisticSeconds;
-        emit SetOptimisticTimeout(_optimisticSeconds);
+        _setOptimisticTimeout(_optimisticSeconds);
     }
 
     // ============ External Functions ============
@@ -274,8 +273,7 @@ contract Replica is Version0, NomadBase {
         external
         onlyOwner
     {
-        optimisticSeconds = _optimisticSeconds;
-        emit SetOptimisticTimeout(_optimisticSeconds);
+        _setOptimisticTimeout(_optimisticSeconds);
     }
 
     /**
@@ -358,6 +356,22 @@ contract Replica is Version0, NomadBase {
     }
 
     // ============ Internal Functions ============
+
+    /**
+     * @notice Set optimistic timeout period for new roots
+     * @dev Called by owner (Governance) or at initialization
+     * @param _optimisticSeconds New optimistic timeout period
+     */
+    function _setOptimisticTimeout(uint256 _optimisticSeconds) internal {
+        // ensure the optimistic timeout is at least 25 minutes
+        require(_optimisticSeconds >= 1500, "optimistic timeout too low");
+        // ensure the optimistic timeout is less than 1 year
+        // (prevents overflow when adding block.timestamp)
+        require(_optimisticSeconds < 31536000, "optimistic timeout too high");
+        // set the optimistic timeout
+        optimisticSeconds = _optimisticSeconds;
+        emit SetOptimisticTimeout(_optimisticSeconds);
+    }
 
     /// @notice Hook for potential future use
     // solhint-disable-next-line no-empty-blocks

--- a/packages/contracts-core/contracts/Replica.sol
+++ b/packages/contracts-core/contracts/Replica.sol
@@ -363,6 +363,11 @@ contract Replica is Version0, NomadBase {
      * @param _optimisticSeconds New optimistic timeout period
      */
     function _setOptimisticTimeout(uint256 _optimisticSeconds) internal {
+        // This allows us to initialize the value to be very low in test envs,
+        // but does not allow governance action to lower a production env below
+        // the safe value
+        uint256 _current = optimisticSeconds;
+        if (_current != 0 && _current > 1500) require(_optimisticSeconds >= 1500, "optimistic timeout too low");
         // ensure the optimistic timeout is less than 1 year
         // (prevents overflow when adding block.timestamp)
         require(_optimisticSeconds < 31536000, "optimistic timeout too high");

--- a/packages/contracts-core/contracts/Replica.sol
+++ b/packages/contracts-core/contracts/Replica.sol
@@ -363,8 +363,6 @@ contract Replica is Version0, NomadBase {
      * @param _optimisticSeconds New optimistic timeout period
      */
     function _setOptimisticTimeout(uint256 _optimisticSeconds) internal {
-        // ensure the optimistic timeout is at least 25 minutes
-        require(_optimisticSeconds >= 1500, "optimistic timeout too low");
         // ensure the optimistic timeout is less than 1 year
         // (prevents overflow when adding block.timestamp)
         require(_optimisticSeconds < 31536000, "optimistic timeout too high");


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below. Bug fixes and new features should include tests.

New contributors should read the contributors guide:
https://github.com/nomad-xyz/monorepo/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building
the documentation.
-->

## Motivation
We wish to add some reasonable input validation to the optimisticSeconds field

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Ensure optimisticSeconds is greater than 25 minutes & less than 1 year. 

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Updated Documentation
- [ ] Updated CHANGELOG.md for the appropriate package
