### PR TITLE
[QSP-22, QSP-26] lock all pragmas to 0.7.6

### DIFF
--- a/packages/contracts-bridge/.solhint.json
+++ b/packages/contracts-bridge/.solhint.json
@@ -1,7 +1,7 @@
 {
   "extends": "solhint:recommended",
   "rules": {
-    "compiler-version": ["error", "^0.6.11"],
+    "compiler-version": ["error", "0.7.6"],
     "func-visibility": ["warn", {"ignoreConstructors":true}],
     "not-rely-on-time": "off",
     "avoid-low-level-calls": "off",

--- a/packages/contracts-bridge/contracts/BridgeMessage.sol
+++ b/packages/contracts-bridge/contracts/BridgeMessage.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
-pragma solidity >=0.6.11;
+pragma solidity 0.7.6;
 
 // ============ External Imports ============
 import {TypedMemView} from "@summa-tx/memview-sol/contracts/TypedMemView.sol";

--- a/packages/contracts-bridge/contracts/BridgeRouter.sol
+++ b/packages/contracts-bridge/contracts/BridgeRouter.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
-pragma solidity >=0.6.11;
+pragma solidity 0.7.6;
 
 // ============ Internal Imports ============
 import {BridgeMessage} from "./BridgeMessage.sol";

--- a/packages/contracts-bridge/contracts/BridgeToken.sol
+++ b/packages/contracts-bridge/contracts/BridgeToken.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
-pragma solidity >=0.6.11;
+pragma solidity 0.7.6;
 
 // ============ Internal Imports ============
 import {BridgeMessage} from "./BridgeMessage.sol";

--- a/packages/contracts-bridge/contracts/ETHHelper.sol
+++ b/packages/contracts-bridge/contracts/ETHHelper.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
-pragma solidity >=0.6.11;
+pragma solidity 0.7.6;
 
 // ============ Internal Imports ============
 import {BridgeRouter} from "./BridgeRouter.sol";

--- a/packages/contracts-bridge/contracts/Encoding.sol
+++ b/packages/contracts-bridge/contracts/Encoding.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
-pragma solidity >=0.6.11;
+pragma solidity 0.7.6;
 
 library Encoding {
     // ============ Constants ============

--- a/packages/contracts-bridge/contracts/TokenRegistry.sol
+++ b/packages/contracts-bridge/contracts/TokenRegistry.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
-pragma solidity >=0.6.11;
+pragma solidity 0.7.6;
 
 // ============ Local Contracts ============
 import {BridgeMessage} from "./BridgeMessage.sol";

--- a/packages/contracts-bridge/contracts/interfaces/IBridgeToken.sol
+++ b/packages/contracts-bridge/contracts/interfaces/IBridgeToken.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
-pragma solidity >=0.6.11;
+pragma solidity 0.7.6;
 
 interface IBridgeToken {
     function initialize() external;

--- a/packages/contracts-bridge/contracts/interfaces/ITokenRegistry.sol
+++ b/packages/contracts-bridge/contracts/interfaces/ITokenRegistry.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
-pragma solidity >=0.6.11;
+pragma solidity 0.7.6;
 
 // ============ Internal Imports ============
 import {IBridgeToken} from "./IBridgeToken.sol";

--- a/packages/contracts-bridge/contracts/interfaces/IWeth.sol
+++ b/packages/contracts-bridge/contracts/interfaces/IWeth.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
-pragma solidity >=0.6.11;
+pragma solidity 0.7.6;
 
 interface IWeth {
     function deposit() external payable;

--- a/packages/contracts-bridge/contracts/test/MockCore.sol
+++ b/packages/contracts-bridge/contracts/test/MockCore.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
-pragma solidity >=0.6.11;
+pragma solidity 0.7.6;
 
 import {MerkleTreeManager} from "@nomad-xyz/contracts-core/contracts/Merkle.sol";
 import {QueueManager} from "@nomad-xyz/contracts-core/contracts/Queue.sol";

--- a/packages/contracts-bridge/contracts/test/MockWeth.sol
+++ b/packages/contracts-bridge/contracts/test/MockWeth.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
-pragma solidity >=0.6.11;
+pragma solidity 0.7.6;
 
 import {BridgeToken} from "../BridgeToken.sol";
 

--- a/packages/contracts-bridge/contracts/test/TestBridgeMessage.sol
+++ b/packages/contracts-bridge/contracts/test/TestBridgeMessage.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
-pragma solidity >=0.6.11;
+pragma solidity 0.7.6;
 
 import "../BridgeMessage.sol";
 

--- a/packages/contracts-bridge/contracts/test/TestBridgeRouter.sol
+++ b/packages/contracts-bridge/contracts/test/TestBridgeRouter.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
-pragma solidity >=0.6.11;
+pragma solidity 0.7.6;
 
 import "../BridgeRouter.sol";
 

--- a/packages/contracts-bridge/contracts/test/TestEncoding.sol
+++ b/packages/contracts-bridge/contracts/test/TestEncoding.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
-pragma solidity >=0.6.11;
+pragma solidity 0.7.6;
 
 import {Encoding} from "../Encoding.sol";
 

--- a/packages/contracts-bridge/contracts/vendored/OZERC20.sol
+++ b/packages/contracts-bridge/contracts/vendored/OZERC20.sol
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: MIT
-
-pragma solidity >=0.6.0 <0.8.0;
+pragma solidity 0.7.6;
 
 // This is modified from "@openzeppelin/contracts/token/ERC20/IERC20.sol"
 // Modifications were made to make the tokenName, tokenSymbol, and

--- a/packages/contracts-core/.solhint.json
+++ b/packages/contracts-core/.solhint.json
@@ -1,7 +1,7 @@
 {
   "extends": "solhint:recommended",
   "rules": {
-    "compiler-version": ["error", "^0.6.11"],
+    "compiler-version": ["error", "0.7.6"],
     "func-visibility": ["warn", {"ignoreConstructors":true}],
     "not-rely-on-time": "off",
     "avoid-low-level-calls": "off",

--- a/packages/contracts-core/contracts/Home.sol
+++ b/packages/contracts-core/contracts/Home.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
-pragma solidity >=0.6.11;
+pragma solidity 0.7.6;
 
 // ============ Internal Imports ============
 import {Version0} from "./Version0.sol";

--- a/packages/contracts-core/contracts/Merkle.sol
+++ b/packages/contracts-core/contracts/Merkle.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
-pragma solidity >=0.6.11;
+pragma solidity 0.7.6;
 
 // ============ Internal Imports ============
 import {MerkleLib} from "./libs/Merkle.sol";

--- a/packages/contracts-core/contracts/NomadBase.sol
+++ b/packages/contracts-core/contracts/NomadBase.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
-pragma solidity >=0.6.11;
+pragma solidity 0.7.6;
 
 // ============ Internal Imports ============
 import {Message} from "./libs/Message.sol";

--- a/packages/contracts-core/contracts/Queue.sol
+++ b/packages/contracts-core/contracts/Queue.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
-pragma solidity >=0.6.11;
+pragma solidity 0.7.6;
 
 // ============ Internal Imports ============
 import {QueueLib} from "./libs/Queue.sol";

--- a/packages/contracts-core/contracts/Replica.sol
+++ b/packages/contracts-core/contracts/Replica.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
-pragma solidity >=0.6.11;
+pragma solidity 0.7.6;
 
 // ============ Internal Imports ============
 import {Version0} from "./Version0.sol";

--- a/packages/contracts-core/contracts/UpdaterManager.sol
+++ b/packages/contracts-core/contracts/UpdaterManager.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
-pragma solidity >=0.6.11;
+pragma solidity 0.7.6;
 
 // ============ Internal Imports ============
 import {IUpdaterManager} from "./interfaces/IUpdaterManager.sol";

--- a/packages/contracts-core/contracts/Version0.sol
+++ b/packages/contracts-core/contracts/Version0.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
-pragma solidity >=0.6.11;
+pragma solidity 0.7.6;
 
 /**
  * @title Version0

--- a/packages/contracts-core/contracts/XAppConnectionManager.sol
+++ b/packages/contracts-core/contracts/XAppConnectionManager.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
-pragma solidity >=0.6.11;
+pragma solidity 0.7.6;
 
 // ============ Internal Imports ============
 import {Home} from "./Home.sol";

--- a/packages/contracts-core/contracts/governance/GovernanceMessage.sol
+++ b/packages/contracts-core/contracts/governance/GovernanceMessage.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
-pragma solidity >=0.6.11;
+pragma solidity 0.7.6;
 pragma experimental ABIEncoderV2;
 
 // ============ External Imports ============

--- a/packages/contracts-core/contracts/governance/GovernanceRouter.sol
+++ b/packages/contracts-core/contracts/governance/GovernanceRouter.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
-pragma solidity >=0.6.11;
+pragma solidity 0.7.6;
 pragma experimental ABIEncoderV2;
 
 // ============ Internal Imports ============

--- a/packages/contracts-core/contracts/interfaces/IMessageRecipient.sol
+++ b/packages/contracts-core/contracts/interfaces/IMessageRecipient.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
-pragma solidity >=0.6.11;
+pragma solidity 0.7.6;
 
 interface IMessageRecipient {
     function handle(

--- a/packages/contracts-core/contracts/interfaces/IUpdaterManager.sol
+++ b/packages/contracts-core/contracts/interfaces/IUpdaterManager.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
-pragma solidity >=0.6.11;
+pragma solidity 0.7.6;
 
 interface IUpdaterManager {
     function slashUpdater(address payable _reporter) external;

--- a/packages/contracts-core/contracts/libs/Merkle.sol
+++ b/packages/contracts-core/contracts/libs/Merkle.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
-pragma solidity >=0.6.11;
+pragma solidity 0.7.6;
 
 // work based on eth2 deposit contract, which is used under CC0-1.0
 

--- a/packages/contracts-core/contracts/libs/Message.sol
+++ b/packages/contracts-core/contracts/libs/Message.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
-pragma solidity >=0.6.11;
+pragma solidity 0.7.6;
 
 import "@summa-tx/memview-sol/contracts/TypedMemView.sol";
 

--- a/packages/contracts-core/contracts/libs/Queue.sol
+++ b/packages/contracts-core/contracts/libs/Queue.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
-pragma solidity >=0.6.11;
+pragma solidity 0.7.6;
 
 /**
  * @title QueueLib

--- a/packages/contracts-core/contracts/libs/TypeCasts.sol
+++ b/packages/contracts-core/contracts/libs/TypeCasts.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
-pragma solidity >=0.6.11;
+pragma solidity 0.7.6;
 
 import "@summa-tx/memview-sol/contracts/TypedMemView.sol";
 

--- a/packages/contracts-core/contracts/test/MysteryMath.sol
+++ b/packages/contracts-core/contracts/test/MysteryMath.sol
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: MIT
-
-pragma solidity >=0.6.11;
+pragma solidity 0.7.6;
 
 abstract contract MysteryMath {
     uint256 public stateVar;

--- a/packages/contracts-core/contracts/test/MysteryMathV1.sol
+++ b/packages/contracts-core/contracts/test/MysteryMathV1.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
+pragma solidity 0.7.6;
 
-pragma solidity >=0.6.11;
 
 import "./MysteryMath.sol";
 

--- a/packages/contracts-core/contracts/test/MysteryMathV2.sol
+++ b/packages/contracts-core/contracts/test/MysteryMathV2.sol
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: MIT
-
-pragma solidity >=0.6.11;
+pragma solidity 0.7.6;
 
 import "./MysteryMath.sol";
 

--- a/packages/contracts-core/contracts/test/TestCommon.sol
+++ b/packages/contracts-core/contracts/test/TestCommon.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
-pragma solidity >=0.6.11;
+pragma solidity 0.7.6;
 
 import "../NomadBase.sol";
 

--- a/packages/contracts-core/contracts/test/TestGovernanceMessage.sol
+++ b/packages/contracts-core/contracts/test/TestGovernanceMessage.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
-pragma solidity >=0.6.11;
+pragma solidity 0.7.6;
 pragma experimental ABIEncoderV2;
 
 import {GovernanceMessage} from "../governance/GovernanceMessage.sol";

--- a/packages/contracts-core/contracts/test/TestGovernanceRouter.sol
+++ b/packages/contracts-core/contracts/test/TestGovernanceRouter.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
-pragma solidity >=0.6.11;
+pragma solidity 0.7.6;
 pragma experimental ABIEncoderV2;
 
 import "../governance/GovernanceRouter.sol";

--- a/packages/contracts-core/contracts/test/TestHome.sol
+++ b/packages/contracts-core/contracts/test/TestHome.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
-pragma solidity >=0.6.11;
+pragma solidity 0.7.6;
 
 import "../Home.sol";
 

--- a/packages/contracts-core/contracts/test/TestMerkle.sol
+++ b/packages/contracts-core/contracts/test/TestMerkle.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
-pragma solidity >=0.6.11;
+pragma solidity 0.7.6;
 
 import "../Merkle.sol";
 

--- a/packages/contracts-core/contracts/test/TestMessage.sol
+++ b/packages/contracts-core/contracts/test/TestMessage.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
-pragma solidity >=0.6.11;
+pragma solidity 0.7.6;
 
 import {TypedMemView} from "@summa-tx/memview-sol/contracts/TypedMemView.sol";
 import {Message} from "../libs/Message.sol";

--- a/packages/contracts-core/contracts/test/TestQueue.sol
+++ b/packages/contracts-core/contracts/test/TestQueue.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
-pragma solidity >=0.6.11;
+pragma solidity 0.7.6;
 
 import "../Queue.sol";
 

--- a/packages/contracts-core/contracts/test/TestRecipient.sol
+++ b/packages/contracts-core/contracts/test/TestRecipient.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
-pragma solidity >=0.6.11;
+pragma solidity 0.7.6;
 
 import {IMessageRecipient} from "../interfaces/IMessageRecipient.sol";
 

--- a/packages/contracts-core/contracts/test/TestReplica.sol
+++ b/packages/contracts-core/contracts/test/TestReplica.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
-pragma solidity >=0.6.11;
+pragma solidity 0.7.6;
 
 import "../Replica.sol";
 

--- a/packages/contracts-core/contracts/test/TestXAppConnectionManager.sol
+++ b/packages/contracts-core/contracts/test/TestXAppConnectionManager.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
-pragma solidity >=0.6.11;
+pragma solidity 0.7.6;
 
 import "../XAppConnectionManager.sol";
 import "../libs/TypeCasts.sol";

--- a/packages/contracts-core/contracts/test/bad-recipient/BadRecipient1.sol
+++ b/packages/contracts-core/contracts/test/bad-recipient/BadRecipient1.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
-pragma solidity >=0.6.11;
+pragma solidity 0.7.6;
 
 import {IMessageRecipient} from "../../interfaces/IMessageRecipient.sol";
 

--- a/packages/contracts-core/contracts/test/bad-recipient/BadRecipient2.sol
+++ b/packages/contracts-core/contracts/test/bad-recipient/BadRecipient2.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
-pragma solidity >=0.6.11;
+pragma solidity 0.7.6;
 
 import {IMessageRecipient} from "../../interfaces/IMessageRecipient.sol";
 

--- a/packages/contracts-core/contracts/test/bad-recipient/BadRecipient3.sol
+++ b/packages/contracts-core/contracts/test/bad-recipient/BadRecipient3.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
-pragma solidity >=0.6.11;
+pragma solidity 0.7.6;
 
 import {IMessageRecipient} from "../../interfaces/IMessageRecipient.sol";
 

--- a/packages/contracts-core/contracts/test/bad-recipient/BadRecipient4.sol
+++ b/packages/contracts-core/contracts/test/bad-recipient/BadRecipient4.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
-pragma solidity >=0.6.11;
+pragma solidity 0.7.6;
 
 import {IMessageRecipient} from "../../interfaces/IMessageRecipient.sol";
 

--- a/packages/contracts-core/contracts/test/bad-recipient/BadRecipient5.sol
+++ b/packages/contracts-core/contracts/test/bad-recipient/BadRecipient5.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
-pragma solidity >=0.6.11;
+pragma solidity 0.7.6;
 
 import {IMessageRecipient} from "../../interfaces/IMessageRecipient.sol";
 

--- a/packages/contracts-core/contracts/test/bad-recipient/BadRecipient6.sol
+++ b/packages/contracts-core/contracts/test/bad-recipient/BadRecipient6.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
-pragma solidity >=0.6.11;
+pragma solidity 0.7.6;
 
 import {IMessageRecipient} from "../../interfaces/IMessageRecipient.sol";
 

--- a/packages/contracts-core/contracts/test/bad-recipient/BadRecipientHandle.sol
+++ b/packages/contracts-core/contracts/test/bad-recipient/BadRecipientHandle.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
-pragma solidity >=0.6.11;
+pragma solidity 0.7.6;
 
 contract BadRecipientHandle {
     function handle(uint32, bytes32) external pure {} // solhint-disable-line no-empty-blocks

--- a/packages/contracts-core/contracts/upgrade/UpgradeBeacon.sol
+++ b/packages/contracts-core/contracts/upgrade/UpgradeBeacon.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.6.11;
+pragma solidity 0.7.6;
 
 // ============ External Imports ============
 import {Address} from "@openzeppelin/contracts/utils/Address.sol";

--- a/packages/contracts-core/contracts/upgrade/UpgradeBeaconController.sol
+++ b/packages/contracts-core/contracts/upgrade/UpgradeBeaconController.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
-pragma solidity >=0.6.11;
+pragma solidity 0.7.6;
 
 // ============ Internal Imports ============
 import {UpgradeBeacon} from "./UpgradeBeacon.sol";

--- a/packages/contracts-core/contracts/upgrade/UpgradeBeaconProxy.sol
+++ b/packages/contracts-core/contracts/upgrade/UpgradeBeaconProxy.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.6.11;
+pragma solidity 0.7.6;
 
 // ============ External Imports ============
 import {Address} from "@openzeppelin/contracts/utils/Address.sol";

--- a/packages/contracts-router/.solhint.json
+++ b/packages/contracts-router/.solhint.json
@@ -1,7 +1,7 @@
 {
   "extends": "solhint:recommended",
   "rules": {
-    "compiler-version": ["error", "^0.6.11"],
+    "compiler-version": ["error", "0.7.6"],
     "func-visibility": ["warn", {"ignoreConstructors":true}],
     "not-rely-on-time": "off",
     "avoid-low-level-calls": "off",

--- a/packages/contracts-router/contracts/Router.sol
+++ b/packages/contracts-router/contracts/Router.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
-pragma solidity >=0.6.11;
+pragma solidity 0.7.6;
 
 // ============ Internal Imports ============
 import {XAppConnectionClient} from "./XAppConnectionClient.sol";

--- a/packages/contracts-router/contracts/XAppConnectionClient.sol
+++ b/packages/contracts-router/contracts/XAppConnectionClient.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
-pragma solidity >=0.6.11;
+pragma solidity 0.7.6;
 
 // ============ External Imports ============
 import {Home} from "@nomad-xyz/contracts-core/contracts/Home.sol";


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below. Bug fixes and new features should include tests.

New contributors should read the contributors guide:
https://github.com/nomad-xyz/monorepo/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building
the documentation.
-->

## Motivation
Solidity pragmas used `>=0.6.11` when they were in reality all being compiled to `0.7.6`
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
For cleanliness & clarity, we'll lock all pragmas to `0.7.6`

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Updated Documentation
- [ ] Updated CHANGELOG.md for the appropriate package
