### PR TITLE
[QSP-34] don't mark messages as Processed when they fail

### DIFF
--- a/packages/contracts-core/contracts/Replica.sol
+++ b/packages/contracts-core/contracts/Replica.sol
@@ -208,6 +208,8 @@ contract Replica is Version0, NomadBase {
         emit Process(_messageHash, true, "");
         // reset re-entrancy guard
         entered = 1;
+        // return true
+        return true;
     }
 
     // ============ External Owner Functions ============

--- a/packages/contracts-core/contracts/Replica.sol
+++ b/packages/contracts-core/contracts/Replica.sol
@@ -59,9 +59,14 @@ contract Replica is Version0, NomadBase {
     /**
      * @notice Emitted when message is processed
      * @param messageHash The keccak256 hash of the message that was processed
+     * @param success TRUE if the call was executed successfully,
+     * FALSE if the call reverted or threw
+     * @param returnData the return data from the external call
      */
     event Process(
-        bytes32 indexed messageHash
+        bytes32 indexed messageHash,
+        bool indexed success,
+        bytes indexed returnData
     );
 
     /**
@@ -200,7 +205,7 @@ contract Replica is Version0, NomadBase {
             _m.body().clone()
         );
         // emit process results
-        emit Process(_messageHash);
+        emit Process(_messageHash, true, "");
         // reset re-entrancy guard
         entered = 1;
     }

--- a/packages/contracts-core/contracts/Replica.sol
+++ b/packages/contracts-core/contracts/Replica.sol
@@ -6,6 +6,7 @@ import {Version0} from "./Version0.sol";
 import {NomadBase} from "./NomadBase.sol";
 import {MerkleLib} from "./libs/Merkle.sol";
 import {Message} from "./libs/Message.sol";
+import {IMessageRecipient} from "./interfaces/IMessageRecipient.sol";
 // ============ External Imports ============
 import {TypedMemView} from "@summa-tx/memview-sol/contracts/TypedMemView.sol";
 
@@ -35,13 +36,6 @@ contract Replica is Version0, NomadBase {
         Processed
     }
 
-    // ============ Immutables ============
-
-    // Minimum gas for message processing
-    uint256 public immutable PROCESS_GAS;
-    // Reserved gas (to ensure tx completes in case message processing runs out)
-    uint256 public immutable RESERVE_GAS;
-
     // ============ Public Storage ============
 
     // Domain of home chain
@@ -65,14 +59,9 @@ contract Replica is Version0, NomadBase {
     /**
      * @notice Emitted when message is processed
      * @param messageHash The keccak256 hash of the message that was processed
-     * @param success TRUE if the call was executed successfully,
-     * FALSE if the call reverted or threw
-     * @param returnData the return data from the external call
      */
     event Process(
-        bytes32 indexed messageHash,
-        bool indexed success,
-        bytes indexed returnData
+        bytes32 indexed messageHash
     );
 
     /**
@@ -96,15 +85,8 @@ contract Replica is Version0, NomadBase {
     // ============ Constructor ============
 
     constructor(
-        uint32 _localDomain,
-        uint256 _processGas,
-        uint256 _reserveGas
-    ) NomadBase(_localDomain) {
-        require(_processGas >= 850_000, "!process gas");
-        require(_reserveGas >= 15_000, "!reserve gas");
-        PROCESS_GAS = _processGas;
-        RESERVE_GAS = _reserveGas;
-    }
+        uint32 _localDomain
+    ) NomadBase(_localDomain) {}
 
     // ============ Initializer ============
 
@@ -199,8 +181,8 @@ contract Replica is Version0, NomadBase {
      * @return _success TRUE iff dispatch transaction succeeded
      */
     function process(bytes memory _message) public returns (bool _success) {
-        bytes29 _m = _message.ref(0);
         // ensure message was meant for this domain
+        bytes29 _m = _message.ref(0);
         require(_m.destination() == localDomain, "!destination");
         // ensure message has been proven
         bytes32 _messageHash = _m.keccak();
@@ -210,55 +192,15 @@ contract Replica is Version0, NomadBase {
         entered = 0;
         // update message status as processed
         messages[_messageHash] = MessageStatus.Processed;
-        // A call running out of gas TYPICALLY errors the whole tx. We want to
-        // a) ensure the call has a sufficient amount of gas to make a
-        //    meaningful state change.
-        // b) ensure that if the subcall runs out of gas, that the tx as a whole
-        //    does not revert (i.e. we still mark the message processed)
-        // To do this, we require that we have enough gas to process
-        // and still return. We then delegate only the minimum processing gas.
-        require(gasleft() >= PROCESS_GAS + RESERVE_GAS, "!gas");
-        // get the message recipient
-        address _recipient = _m.recipientAddress();
-        // set up for assembly call
-        uint256 _toCopy;
-        uint256 _maxCopy = 256;
-        uint256 _gas = PROCESS_GAS;
-        // allocate memory for returndata
-        bytes memory _returnData = new bytes(_maxCopy);
-        bytes memory _calldata = abi.encodeWithSignature(
-            "handle(uint32,uint32,bytes32,bytes)",
+        // call handle function
+        IMessageRecipient(_m.recipientAddress()).handle(
             _m.origin(),
             _m.nonce(),
             _m.sender(),
             _m.body().clone()
         );
-        // dispatch message to recipient
-        // by assembly calling "handle" function
-        // we call via assembly to avoid memcopying a very large returndata
-        // returned by a malicious contract
-        assembly {
-            _success := call(
-                _gas, // gas
-                _recipient, // recipient
-                0, // ether value
-                add(_calldata, 0x20), // inloc
-                mload(_calldata), // inlen
-                0, // outloc
-                0 // outlen
-            )
-            // limit our copy to 256 bytes
-            _toCopy := returndatasize()
-            if gt(_toCopy, _maxCopy) {
-                _toCopy := _maxCopy
-            }
-            // Store the length of the copied bytes
-            mstore(_returnData, _toCopy)
-            // copy the bytes from returndata[0:_toCopy]
-            returndatacopy(add(_returnData, 0x20), 0, _toCopy)
-        }
         // emit process results
-        emit Process(_messageHash, _success, _returnData);
+        emit Process(_messageHash);
         // reset re-entrancy guard
         entered = 1;
     }

--- a/packages/contracts-core/contracts/test/TestReplica.sol
+++ b/packages/contracts-core/contracts/test/TestReplica.sol
@@ -9,10 +9,8 @@ contract TestReplica is Replica {
     using Message for bytes29;
 
     constructor(
-        uint32 _localDomain,
-        uint256,
-        uint256
-    ) Replica(_localDomain, 850_000, 15_000) {} // solhint-disable-line no-empty-blocks
+        uint32 _localDomain
+    ) Replica(_localDomain) {} // solhint-disable-line no-empty-blocks
 
     function setRemoteDomain(uint32 _remoteDomain) external {
         remoteDomain = _remoteDomain;

--- a/packages/deploy/src/bridge/BridgeContracts.ts
+++ b/packages/deploy/src/bridge/BridgeContracts.ts
@@ -291,8 +291,6 @@ export default class BridgeContracts extends AbstractBridgeDeploy<config.EvmBrid
 
     const factory = new contracts.BridgeRouter__factory(this.deployer);
     const implementation = await factory.deploy(
-      // config.bridgeConfiguration.mintGas,  // future
-      // config.bridgeConfiguration.deployGas, // future
       this.overrides,
     );
     await implementation.deployTransaction.wait(this.confirmations);

--- a/packages/deploy/src/core/CoreContracts.ts
+++ b/packages/deploy/src/core/CoreContracts.ts
@@ -456,15 +456,9 @@ export default class EvmCoreDeploy extends AbstractCoreDeploy<config.EvmCoreCont
 
       const constructorArguments = [
         localConfig.domain,
-        localConfig.configuration.processGas,
-        localConfig.configuration.reserveGas,
-        // localConfig.configuration.maximumGas,  // future
       ];
       const replica = await factory.deploy(
         constructorArguments[0],
-        constructorArguments[1],
-        constructorArguments[2],
-        // localConfig.configuration.maximumGas,  // future
         this.overrides,
       );
       await replica.deployTransaction.wait(this.confirmations);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1766,13 +1766,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@nomad-xyz/configuration@npm:^0.1.0-rc.23":
-  version: 0.1.0-rc.23
-  resolution: "@nomad-xyz/configuration@npm:0.1.0-rc.23"
-  checksum: 45f5e5efb0394d06299304f09b681e53deece1c8dd8b17fe1091fc09286f3ae26c3ccae8daf523c63d5e3614492845680b844fd50677788fe9e371de767fabdc
-  languageName: node
-  linkType: hard
-
 "@nomad-xyz/contract-interfaces@npm:1.1.1":
   version: 1.1.1
   resolution: "@nomad-xyz/contract-interfaces@npm:1.1.1"
@@ -1784,7 +1777,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@nomad-xyz/contracts-bridge@1.0.0-rc.2, @nomad-xyz/contracts-bridge@^1.0.0-rc.2, @nomad-xyz/contracts-bridge@workspace:^, @nomad-xyz/contracts-bridge@workspace:packages/contracts-bridge":
+"@nomad-xyz/contracts-bridge@1.0.0-rc.2, @nomad-xyz/contracts-bridge@workspace:^, @nomad-xyz/contracts-bridge@workspace:packages/contracts-bridge":
   version: 0.0.0-use.local
   resolution: "@nomad-xyz/contracts-bridge@workspace:packages/contracts-bridge"
   dependencies:
@@ -1815,7 +1808,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@nomad-xyz/contracts-core@^1.0.0-rc.2, @nomad-xyz/contracts-core@workspace:^, @nomad-xyz/contracts-core@workspace:packages/contracts-core":
+"@nomad-xyz/contracts-core@workspace:^, @nomad-xyz/contracts-core@workspace:packages/contracts-core":
   version: 0.0.0-use.local
   resolution: "@nomad-xyz/contracts-core@workspace:packages/contracts-core"
   dependencies:
@@ -2032,20 +2025,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@nomad-xyz/sdk-bridge@npm:^1.0.0-rc.17":
-  version: 1.0.0-rc.17
-  resolution: "@nomad-xyz/sdk-bridge@npm:1.0.0-rc.17"
-  dependencies:
-    "@nomad-xyz/configuration": ^0.1.0-rc.23
-    "@nomad-xyz/contracts-bridge": ^1.0.0-rc.2
-    "@nomad-xyz/sdk": ^2.0.0-rc.17
-    ethers: ^5.0.0
-    web3: ^1.6.1
-  checksum: 3a6ee6c05b8cbe87c42d164739749c97b2b5d5dff5a53e6c9a9a1073b19dda30229dad82bc31e1edb84ecea361e8bc99a11d7e26bd284ada0e292c71b258bd44
-  languageName: node
-  linkType: hard
-
-"@nomad-xyz/sdk-bridge@workspace:^, @nomad-xyz/sdk-bridge@workspace:packages/sdk-bridge":
+"@nomad-xyz/sdk-bridge@^1.0.0-rc.17, @nomad-xyz/sdk-bridge@workspace:^, @nomad-xyz/sdk-bridge@workspace:packages/sdk-bridge":
   version: 0.0.0-use.local
   resolution: "@nomad-xyz/sdk-bridge@workspace:packages/sdk-bridge"
   dependencies:
@@ -2071,22 +2051,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@nomad-xyz/sdk-govern@npm:^1.0.0-rc.17":
-  version: 1.0.0-rc.17
-  resolution: "@nomad-xyz/sdk-govern@npm:1.0.0-rc.17"
-  dependencies:
-    "@gnosis.pm/safe-core-sdk": ^2.0.0
-    "@gnosis.pm/safe-ethers-adapters": ^0.1.0-alpha.8
-    "@gnosis.pm/safe-ethers-lib": ^1.0.0
-    "@nomad-xyz/configuration": ^0.1.0-rc.23
-    "@nomad-xyz/sdk": ^2.0.0-rc.17
-    ethers: ^5.4.6
-    web3: ^1.6.1
-  checksum: c2a7d1905d9b7e6a7123310eb6d01a8c05779f69a500d2d9f6891d7a01462fb18b0d80ef5972ba88ee79fc5c9f2d72af54eedeaf6d86c63f7a43c515ea8e5998
-  languageName: node
-  linkType: hard
-
-"@nomad-xyz/sdk-govern@workspace:^, @nomad-xyz/sdk-govern@workspace:packages/sdk-govern":
+"@nomad-xyz/sdk-govern@^1.0.0-rc.17, @nomad-xyz/sdk-govern@workspace:^, @nomad-xyz/sdk-govern@workspace:packages/sdk-govern":
   version: 0.0.0-use.local
   resolution: "@nomad-xyz/sdk-govern@workspace:packages/sdk-govern"
   dependencies:
@@ -2115,20 +2080,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@nomad-xyz/sdk@npm:^2.0.0-rc.17":
-  version: 2.0.0-rc.17
-  resolution: "@nomad-xyz/sdk@npm:2.0.0-rc.17"
-  dependencies:
-    "@nomad-xyz/configuration": ^0.1.0-rc.23
-    "@nomad-xyz/contracts-core": ^1.0.0-rc.2
-    "@nomad-xyz/multi-provider": ^1.0.0-rc.4
-    axios: ^0.27.2
-    ethers: ^5.0.0
-  checksum: 31694539411754a30b96ea222d32f568cc5b0626e42fae2e6f5c60dac5bb9fcb85fe608c6cdcc3ee434088bec81545762718c1223c981c7c0e219015d85de25d
-  languageName: node
-  linkType: hard
-
-"@nomad-xyz/sdk@workspace:^, @nomad-xyz/sdk@workspace:packages/sdk":
+"@nomad-xyz/sdk@^2.0.0-rc.17, @nomad-xyz/sdk@workspace:^, @nomad-xyz/sdk@workspace:packages/sdk":
   version: 0.0.0-use.local
   resolution: "@nomad-xyz/sdk@workspace:packages/sdk"
   dependencies:
@@ -8250,7 +8202,7 @@ __metadata:
   dependencies:
     bn.js: ^4.11.8
     ethereumjs-util: ^6.0.0
-  checksum: 03127d09960e5f8a44167463faf25b2894db2f746376dbb8195b789ed11762f93db9c574eaa7c498c400063508e9dfc1c80de2edf5f0e1406b25c87d860ff2f1
+  checksum: ae074be0bb012857ab5d3ae644d1163b908a48dd724b7d2567cfde309dc72222d460438f2411936a70dc949dc604ce1ef7118f7273bd525815579143c907e336
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Motivation
In our original protocol design, we wanted message processing to be attempted exactly once, regardless of whether the subsequent `handle` call to the app reverted.  To guarantee this, we had to introduce some complexity to our Replica contracts: 
1. introduced gas-awareness to the protocol (with fields like `PROCESS_GAS`) to ensure that a malicious processor could not under-gas a transaction to cause it to fail
2. did some bespoke engineering like `ExcessivelySafeCall.sol` to ensure that the call could not be made to fail maliciously in other ways

These pieces of engineering introduced some challenges, such as: 
1. gas awareness made it more complicated to deploy on chains with different gas metering, like Optimism and Arbitrum, and brittle to upgrades that change gas metering, such as Arbitrum Nitro or Optimism Bedrock
2. failing transactions are beneficial in some cases, and harmful in others. For current apps like the Nomad Bridge, message handling _should_ never fail.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
We will remove the possibility of message handling to fail. 

This means that messages will always be processable until they succeed, allowing for retrying messages. 

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Update Tests
- [ ] Update Documentation
   - [ ] Deploy config docs
   - [ ] docs.nomad.xyz
- [ ] Update CHANGELOG.md for the appropriate package
- [ ] Update config package
- [ ] Update agents
