### PR TITLE
deploy from tagged contract version

### DIFF
--- a/packages/deploy/CHANGELOG.md
+++ b/packages/deploy/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Unreleased
 
+- deploy from tagged contract versions (1.0.0-rc.2)
 - feature: deploy script doesn't throw, but collect errors
 - chore: bump configuration to rc.23
 - fix: add goerli overrides to overrides.json

--- a/packages/deploy/package.json
+++ b/packages/deploy/package.json
@@ -22,9 +22,9 @@
   },
   "dependencies": {
     "@nomad-xyz/configuration": "^0.1.0-rc.23",
-    "@nomad-xyz/contracts-bridge": "workspace:^",
-    "@nomad-xyz/contracts-core": "workspace:^",
-    "@nomad-xyz/contracts-router": "workspace:^",
+    "@nomad-xyz/contracts-bridge": "1.0.0-rc.2",
+    "@nomad-xyz/contracts-core": "1.0.0-rc.2",
+    "@nomad-xyz/contracts-router": "1.0.0-rc.2",
     "@nomad-xyz/multi-provider": "workspace:^",
     "@nomad-xyz/sdk": "workspace:^",
     "@nomad-xyz/sdk-govern": "workspace:^",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1808,7 +1808,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@nomad-xyz/contracts-core@workspace:^, @nomad-xyz/contracts-core@workspace:packages/contracts-core":
+"@nomad-xyz/contracts-core@1.0.0-rc.2, @nomad-xyz/contracts-core@workspace:^, @nomad-xyz/contracts-core@workspace:packages/contracts-core":
   version: 0.0.0-use.local
   resolution: "@nomad-xyz/contracts-core@workspace:packages/contracts-core"
   dependencies:
@@ -1836,7 +1836,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@nomad-xyz/contracts-router@workspace:^, @nomad-xyz/contracts-router@workspace:packages/contracts-router":
+"@nomad-xyz/contracts-router@1.0.0-rc.2, @nomad-xyz/contracts-router@workspace:^, @nomad-xyz/contracts-router@workspace:packages/contracts-router":
   version: 0.0.0-use.local
   resolution: "@nomad-xyz/contracts-router@workspace:packages/contracts-router"
   dependencies:
@@ -1871,9 +1871,9 @@ __metadata:
   resolution: "@nomad-xyz/deploy@workspace:packages/deploy"
   dependencies:
     "@nomad-xyz/configuration": ^0.1.0-rc.23
-    "@nomad-xyz/contracts-bridge": "workspace:^"
-    "@nomad-xyz/contracts-core": "workspace:^"
-    "@nomad-xyz/contracts-router": "workspace:^"
+    "@nomad-xyz/contracts-bridge": 1.0.0-rc.2
+    "@nomad-xyz/contracts-core": 1.0.0-rc.2
+    "@nomad-xyz/contracts-router": 1.0.0-rc.2
     "@nomad-xyz/multi-provider": "workspace:^"
     "@nomad-xyz/sdk": "workspace:^"
     "@nomad-xyz/sdk-govern": "workspace:^"


### PR DESCRIPTION
## Motivation
Deploy repo was deploying from workspace version of the contracts, not tagged npm version. This didn't affect the source code deploys as we had frozen the contract code, but needs to be changed nevertheless. 

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Update deploy package to use tagged contract versions rather than workspace.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Updated Documentation
- [ ] Updated CHANGELOG.md for the appropriate package
