### PR TITLE
Revert PR #299 (QSP-4)

### DIFF
--- a/packages/contracts-core/contracts/libs/Queue.sol
+++ b/packages/contracts-core/contracts/libs/Queue.sol
@@ -121,7 +121,7 @@ library QueueLib {
         view
         returns (bool)
     {
-        for (uint256 i = _q.last; i >= _q.first; i--) {
+        for (uint256 i = _q.first; i <= _q.last; i++) {
             if (_q.queue[i] == _item) {
                 return true;
             }


### PR DESCRIPTION
We revert the PR, as we weren't happy with the mitigation. 

We intend to remove root ordering in the near future, but due to the complexity of the endeavor (in both designing a solution and upgrading the system), we will PR the removal at a later time.