### PR TITLE
fix: install dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules/
+lib/
 yarn-error.log
 **/tsconfig.tsbuildinfo
 dist/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "lib/forge-std"]
-	path = lib/forge-std
-	url = https://github.com/foundry-rs/forge-std

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -14,6 +14,6 @@ if [ -d "../lib/forge-std" ]; then
     echo "Dep directory found, but it's empty"
     echo "Cleaning up and installing deps.."
     rm -rf ../lib/forge-std
+  fi
 fi
-  forge install foundry-rs/forge-std@5645100
-fi
+forge install foundry-rs/forge-std@5645100 --no-git

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -6,8 +6,14 @@ set -e
 cd "$(dirname "$0")"
 echo "Installing forge deps.."
 if [ -d "../lib/forge-std" ]; then
-  echo "Deps already installed"
-  echo "Skipping.."
-else
+  if [ "$(ls -A ../lib/forge-std)" ]; then
+    echo "Deps already installed"
+    echo "Skipping.."
+    exit 0
+  else
+    echo "Dep directory found, but it's empty"
+    echo "Cleaning up and installing deps.."
+    rm -rf ../lib/forge-std
+fi
   forge install foundry-rs/forge-std@5645100
 fi


### PR DESCRIPTION
- use `no-git` option when install libraries with forge
- Add `lib`. to `.gitignore`
- If `install-deps.sh` script doesn't find the dependencies, or if the dependency directory is empty, it will proceed to install it via `forge install`, pinned at a specific version
- 