### PR TITLE
fix: use ethers max constant instead of max safe int

### DIFF
--- a/packages/sdk-bridge/src/BridgeContext.ts
+++ b/packages/sdk-bridge/src/BridgeContext.ts
@@ -273,7 +273,7 @@ export class BridgeContext extends NomadContext {
     if (approved.lt(amount)) {
       const tx = await fromToken.approve(
         bridgeAddress,
-        Number.MAX_SAFE_INTEGER - 10, // subtract some to prevent numeric fault overflow in ethers
+        ethers.constants.MaxUint256,
         overrides,
       );
       await tx.wait();


### PR DESCRIPTION
## Motivation

Was running into numeric fault overflow when using `Number.MAX_SAFE_INT`

## Solution

Use `ethers.constants.MaxUint256` instead

## PR Checklist

- [ ] Added Tests
- [ ] Updated Documentation
- [x] Updated CHANGELOG.md for the appropriate package
