### PR TITLE
feat: Export version from TS package

### DIFF
--- a/packages/contracts-bridge/CHANGELOG.md
+++ b/packages/contracts-bridge/CHANGELOG.md
@@ -2,4 +2,5 @@
 
 ### Unreleased
 
+- feat: Export version from TS package
 - chore: disable metadata hash in hardhat compilation

--- a/packages/contracts-bridge/index.ts
+++ b/packages/contracts-bridge/index.ts
@@ -17,3 +17,5 @@ export const BRIDGE_ROUTER_SPECIFIER = `${root}/BridgeRouter.sol:BridgeRouter`;
 export const BRIDGE_TOKEN_SPECIFIER = `${root}/BridgeToken.sol:BridgeToken`;
 export const ETH_HELPER_SPECIFIER = `${root}/ETHHelper.sol:ETHHelper`;
 export const TOKEN_REGISTRY_SPECIFIER = `${root}/TokenRegistry.sol:TokenRegistry`;
+
+export { version } from "./package.json";

--- a/packages/contracts-bridge/tsconfig.json
+++ b/packages/contracts-bridge/tsconfig.json
@@ -13,5 +13,10 @@
     "../../node_modules",
     "./hardhat.config.ts"
   ],
-  "include": ["index.ts", "./src/*.ts", "./src/factories/*.ts"]
+  "include": [
+    "index.ts",
+    "./src/*.ts",
+    "./src/factories/*.ts",
+    "./package.json"
+  ]
 }

--- a/packages/contracts-core/CHANGELOG.md
+++ b/packages/contracts-core/CHANGELOG.md
@@ -2,4 +2,5 @@
 
 ### Unreleased
 
+- feat: Export version from TS package
 - chore: disable metadata hash in hardhat compilation

--- a/packages/contracts-core/index.ts
+++ b/packages/contracts-core/index.ts
@@ -29,3 +29,5 @@ export const UPGRADE_BEACON_SPECIFIER = `${root}/upgrade/UpgradeBeacon.sol:Upgra
 export const UBP_SPECIFIER = `${root}/upgrade/UpgradeBeaconProxy.sol:UpgradeBeaconProxy`;
 export const UBC_SPECIFIER = `${root}/upgrade/UpgradeBeaconController.sol:UpgradeBeaconController`;
 export const XCM_SPECIFIER = `${root}/XAppConnectionManager.sol:XAppConnectionManager`;
+
+export { version } from "./package.json";

--- a/packages/contracts-core/tsconfig.json
+++ b/packages/contracts-core/tsconfig.json
@@ -2,8 +2,7 @@
   "extends": "../tsconfig.package.json",
   "compilerOptions": {
     "outDir": "./dist",
-    "composite": true,
-    "resolveJsonModule": true
+    "composite": true
   },
   "exclude": [
     "./node_modules",

--- a/packages/contracts-core/tsconfig.json
+++ b/packages/contracts-core/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../tsconfig.package.json",
   "compilerOptions": {
     "outDir": "./dist",
-    "composite": true
+    "composite": true,
+    "resolveJsonModule": true
   },
   "exclude": [
     "./node_modules",
@@ -13,5 +14,10 @@
     "../../node_modules",
     "./hardhat.config.ts"
   ],
-  "include": ["index.ts", "./src/*.ts", "./src/factories/*.ts"]
+  "include": [
+    "index.ts",
+    "./src/*.ts",
+    "./src/factories/*.ts",
+    "./package.json"
+  ]
 }

--- a/packages/contracts-router/CHANGELOG.md
+++ b/packages/contracts-router/CHANGELOG.md
@@ -2,4 +2,5 @@
 
 ### Unreleased
 
+- feat: Export version from TS package
 - chore: disable metadata hash in hardhat compilation

--- a/packages/contracts-router/index.ts
+++ b/packages/contracts-router/index.ts
@@ -3,3 +3,5 @@
 export type { Router } from "./src/Router";
 
 export { Router__factory } from "./src/factories/Router__factory";
+
+export { version } from "./package.json";

--- a/packages/contracts-router/tsconfig.json
+++ b/packages/contracts-router/tsconfig.json
@@ -13,5 +13,10 @@
     "../../node_modules",
     "hardhat.config.ts"
   ],
-  "include": ["index.ts", "./src/*.ts", "./src/factories/*.ts"]
+  "include": [
+    "index.ts",
+    "./src/*.ts",
+    "./src/factories/*.ts",
+    "./package.json"
+  ]
 }

--- a/packages/contracts-router/tsconfig.json
+++ b/packages/contracts-router/tsconfig.json
@@ -11,7 +11,7 @@
     "./scripts",
     "./tmp.ts",
     "../../node_modules",
-    "hardhat.config.ts"
+    "./hardhat.config.ts"
   ],
   "include": [
     "index.ts",

--- a/packages/tsconfig.package.json
+++ b/packages/tsconfig.package.json
@@ -1,9 +1,5 @@
 {
-  "exclude": [
-    "**/dist/**",
-    "**/node_modules/**",
-    "**/tests/**"
-  ],
+  "exclude": ["**/dist/**", "**/node_modules/**", "**/tests/**"],
   "compilerOptions": {
     "composite": true,
     "declaration": true,
@@ -21,6 +17,7 @@
     "preserveSymlinks": true,
     "preserveWatchOutput": true,
     "pretty": false,
+    "resolveJsonModule": true,
     "sourceMap": true,
     "target": "es6",
     "strict": true


### PR DESCRIPTION
Allow downstream users to identify the contract version via the contract TS packages

## Motivation

Future work may want to know whether it's using a compatible contract version. E.g. deploy script running updates may wish to know that it's on a later version than the previous contract version

## Solution

export `version` at the root level of each contract package

## PR Checklist

- [ ] Added Tests
- [ ] Updated Documentation
- [x] Updated CHANGELOG.md for the appropriate package
