### PR TITLE
fix: request browser not to cache fetched config files

### DIFF
--- a/packages/sdk/src/NomadContext.ts
+++ b/packages/sdk/src/NomadContext.ts
@@ -296,7 +296,16 @@ export class NomadContext extends MultiProvider<config.Domain> {
    */
   static async fetchConfig(environment: string): Promise<config.NomadConfig> {
     const uri = `https://nomad-xyz.github.io/config/${environment}.json`;
-    const confStr: string = await (await axios.get(uri)).data;
+    const confStr: string = await (
+      await axios.get(uri, {
+        // query URL without using browser cache
+        headers: {
+          'Cache-Control': 'no-cache',
+          Pragma: 'no-cache',
+          Expires: '0',
+        },
+      })
+    ).data;
     return config.configFromString(confStr);
   }
 


### PR DESCRIPTION

## Motivation

Ensure that browsers can properly get new config info on page refresh

## Solution

Add no-cache headers to axios requests

## PR Checklist

- [ ] Added Tests
- [ ] Updated Documentation
- [x] Updated CHANGELOG.md for the appropriate package
