### PR TITLE
fix: fetch warns on failure

### DIFF
--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Unreleased
 
+- fix: `NomadContext.fetch` warns on failure
 - fix: request browser not to cache fetched config files
 - fix: update replica message status getter for new replica mapping
 

--- a/packages/sdk/src/NomadContext.ts
+++ b/packages/sdk/src/NomadContext.ts
@@ -332,7 +332,12 @@ export class NomadContext extends MultiProvider<config.Domain> {
       const config = await NomadContext.fetchConfig(env);
       return new this(config);
     } catch (e: unknown) {
-      if (allowFallback) return new this(env);
+      if (allowFallback) {
+        console.warn(
+          `Unable to retrieve config ${env}. Falling back to built-in config.\n${e}`,
+        );
+        return new this(env);
+      }
       throw e;
     }
   }


### PR DESCRIPTION
## Motivation

Help devs diagnose config fetching issues

## Solution

If fetch falls back to a builtin config, it `console.warn` logs the error that caused fallback

## PR Checklist

- [ ] Added Tests
- [ ] Updated Documentation
- [x] Updated CHANGELOG.md for the appropriate package
