### PR TITLE
fix: execute script silent no-op if contract or bad key

### DIFF
--- a/packages/sdk-govern/CHANGELOG.md
+++ b/packages/sdk-govern/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Unreleased
 
+- update `executeGovernorDomain` script to throw informative errors when it cannot submit the transaction
+
 ### 1.0.0-rc.17
 
 - chore: bump configuration to v0.1.0-rc.23

--- a/packages/sdk-govern/scripts/executeGovernorDomain.ts
+++ b/packages/sdk-govern/scripts/executeGovernorDomain.ts
@@ -46,7 +46,7 @@ async function run() {
     // if the signer provided is not the governor,
     // inform the caller
     if (!equalIds(governor, signer.address)) {
-        throw new Error(`Signer is not the Governor key. Update SIGNER_KEY in .env\nExpected Governor: ${governor}\nActual Provided: ${signer.address}`);
+        throw new Error(`Signer is not the Governor key. Update SIGNER_KEY in .env \nExpected Governor: ${governor} \nActual Provided: ${signer.address}`);
     }
 
     // if the governor is an EOA

--- a/packages/sdk-govern/scripts/executeGovernorDomain.ts
+++ b/packages/sdk-govern/scripts/executeGovernorDomain.ts
@@ -35,18 +35,29 @@ async function run() {
     const governorCore = await context.governorCore();
     const governor = await governorCore.governanceRouter.governor();
 
-    // if provided signer is the governor, execute the batch directly
-    // otherwise, send the built transaction to the governor gnosis safe
-    if (equalIds(governor, signer.address)) {
-        console.log("Sending governance tx...");
-        const txResponse = await batch.execute();
-        const receipt = await txResponse.wait();
-        console.log("Governance tx mined!!");
-        console.log("   Transaction Hash: ", receipt.transactionHash);
-        console.log("   Block Explorer: ", blockExplorer);
-    } else {
-        // TODO: send to gnosis safe directly
+    // if governor is a contract (not a signer),
+    // inform the caller
+    // TODO: submit transaction directly via gnosis safe API instead of throwing
+    const governorCode = await provider.getCode(governor);
+    if (governorCode != "0x") {
+        throw new Error(`Governor in ${CONFIG.environment} is a contract - likely a Gnosis multisig \nSubmit governance transactions on https://gnosis-safe.io/ \nAddress: ${governor} \nChain: ${context.resolveDomainName(domain)}`);
     }
+
+    // if the signer provided is not the governor,
+    // inform the caller
+    if (!equalIds(governor, signer.address)) {
+        throw new Error(`Signer is not the Governor key. Update SIGNER_KEY in .env\nExpected Governor: ${governor}\nActual Provided: ${signer.address}`);
+    }
+
+    // if the governor is an EOA
+    // that matches the provided signer
+    // execute the transactions
+    console.log("Sending governance tx...");
+    const txResponse = await batch.execute();
+    const receipt = await txResponse.wait();
+    console.log("Governance tx mined!!");
+    console.log("   Transaction Hash: ", receipt.transactionHash);
+    console.log("   Block Explorer: ", blockExplorer);
 
     console.log("DONE!");
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below. Bug fixes and new features should include tests.

New contributors should read the contributors guide:
https://github.com/nomad-xyz/monorepo/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building
the documentation.
-->

## Motivation
In the script used to execute governance actions, if the caller provided a signing key which was not equal to the governor address, the script was a no-op but appeared to succeed. This behavior was easy to cause a caller to mistakenly believe they had successfully executed the transactions.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Add informative errors for any case in which the provided signing key is not equal to the governor address.
1. if the governor is a contract, point the caller to Gnosis (future: submit tx directly via Gnosis) 
2. if the governor is an EOA but the provided key is incorrect, inform the caller

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Updated Documentation
- [ ] Updated CHANGELOG.md for the appropriate package
