### PR TITLE
docs: document webpack config for front-end

### DIFF
--- a/packages/sdk-bridge/README.md
+++ b/packages/sdk-bridge/README.md
@@ -15,6 +15,27 @@ networks.
 
 -------------------------
 
+### Setup (front-end only)
+
+Configure webpack with `wasm`, `syncWebAssembly` and `topLevelAwait`:
+
+```js
+module: {
+  rules: [
+    {
+      test: /\.wasm$/,
+      type: 'webassembly/sync',
+    },
+  ],
+},
+experiments: {
+  syncWebAssembly: true,
+  topLevelAwait: true,
+},
+```
+
+-------------------------
+
 ### Intended Usage
 
 Instantiate a [BridgeContext](https://docs.nomad.xyz/sdk-bridge/classes/bridgecontext):

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -13,6 +13,27 @@ developers to easily interact with the Nomad system on any number of networks.
 
 -------------------------
 
+### Setup (front-end only)
+
+Configure webpack with `wasm`, `syncWebAssembly` and `topLevelAwait`:
+
+```js
+module: {
+  rules: [
+    {
+      test: /\.wasm$/,
+      type: 'webassembly/sync',
+    },
+  ],
+},
+experiments: {
+  syncWebAssembly: true,
+  topLevelAwait: true,
+},
+```
+
+-------------------------
+
 ### Intended Usage
 
 Instantiate a [NomadContext](https://docs.nomad.xyz/sdk/classes/nomadcontext):


### PR DESCRIPTION
Document webpack config for front-end in README for sdk/sdk-bridge

## Motivation

This is documented in the example repo, but is easily missed.  Very common question and very frustrating, so we should make it more visible

## Solution

Document the thing
Republish packages to update documentation on npm

## PR Checklist

- [ ] Added Tests
- [x] Updated Documentation
- [ ] Updated CHANGELOG.md for the appropriate package
