### PR TITLE
fix: use default express prom bundle setup for indexer api

### DIFF
--- a/packages/indexer/src/api/index.ts
+++ b/packages/indexer/src/api/index.ts
@@ -7,16 +7,13 @@ import {
   ApolloServerPluginLandingPageGraphQLPlayground,
 } from 'apollo-server-core';
 import http from 'http';
-import {
-  getDB,
-  getGraphqlSchema,
-  getMetricsMiddleware,
-  initSentry,
-  startMetricsServer,
-} from './utils';
+import { getDB, getGraphqlSchema, initSentry } from './utils';
 import * as Sentry from '@sentry/node';
 import { isProduction, port } from '../config';
 import router from './routes';
+import promBundle from 'express-prom-bundle';
+import { prefix } from '../core/metrics';
+import { register } from 'prom-client';
 
 const app = express();
 
@@ -31,6 +28,20 @@ if (isProduction) {
 
 app.use(cors());
 app.disable('x-powered-by');
+
+// NOTE: add this middleware before any routes that we want to collect metrics on.
+// If we want to avoid collecting metrics for any endpoints, simply add the route above before this.
+// The metrics are served on /metrics
+app.use(
+  promBundle({
+    // see all options here (https://github.com/jochen-schweizer/express-prom-bundle#options)
+    httpDurationMetricName: prefix + '_api',
+    buckets: [0.1, 0.3, 0.6, 1, 1.5, 2.5, 5],
+    includeMethod: true,
+    includePath: true,
+    promRegistry: register,
+  }),
+);
 
 // add all the routes
 app.use('/', router);
@@ -57,10 +68,6 @@ app.use('/', router);
     // The error handler must be before any other error middleware and after all controllers
     app.use(Sentry.Handlers.errorHandler());
   }
-
-  startMetricsServer();
-
-  app.use(getMetricsMiddleware());
 
   await graphqlServer.start();
   graphqlServer.applyMiddleware({ app });

--- a/packages/indexer/src/config.ts
+++ b/packages/indexer/src/config.ts
@@ -28,6 +28,7 @@ export const batchSize = parseInt(process.env.BATCH_SIZE || '2000');
 export const redisUrl = process.env.REDIS_URL || 'redis://redis:6379';
 
 // API CONFIG
+// TODO: determine if we still need metricsPort
 export const metricsPort = parseInt(process.env.METRICS_PORT || '9090');
 export const useAllResolvers = process.env.API_USE_ALL_RESOLVERS === 'TRUE';
 export const gitCommit = process.env.GIT_COMMIT;

--- a/packages/indexer/src/core/utils.ts
+++ b/packages/indexer/src/core/utils.ts
@@ -276,14 +276,3 @@ export function shuffle<V>(array: V[]): V[] {
 export function onlyUnique<T>(value: T, index: number, self: T[]): boolean {
   return self.indexOf(value) === index;
 }
-
-export function randomString(length: number) {
-  let result = '';
-  const characters =
-    'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
-  const charactersLength = characters.length;
-  for (let i = 0; i < length; i++) {
-    result += characters.charAt(Math.floor(Math.random() * charactersLength));
-  }
-  return result;
-}


### PR DESCRIPTION
## Motivation

Fine to follow the default express prom bundle metrics to the /metrics endpoint

## Solution

Simplify the indexer api setup

## PR Checklist

- [ ] Added Tests
- [ ] Updated Documentation
- [x] Updated CHANGELOG.md for the appropriate package
