### PR TITLE
fix: use cache bounded on apollo server to address DoS attack warning

### DIFF
--- a/packages/indexer/CHANGELOG.md
+++ b/packages/indexer/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Unreleased
 
+- fix: use 'bounded' cache setting on apollo server
 - chore: bump sdk, sdk-bridge, multi-provider, contracts-bridge package versions
 - fix: update yarn migrate script references
 - fix: re-add metrics server

--- a/packages/indexer/package.json
+++ b/packages/indexer/package.json
@@ -33,9 +33,9 @@
     "@types/cors": "^2.8.12",
     "@types/express": "^4.17.13",
     "@types/redis": "^4.0.11",
-    "apollo-server": "3.7.0",
-    "apollo-server-core": "3.7.0",
-    "apollo-server-express": "3.7.0",
+    "apollo-server": "3.9.0",
+    "apollo-server-core": "3.9.0",
+    "apollo-server-express": "3.9.0",
     "axios": "^0.26.0",
     "bunyan": "^1.8.15",
     "class-validator": "^0.13.2",
@@ -58,7 +58,7 @@
     "typescript": "^4.4.3"
   },
   "devDependencies": {
-    "@apollo/client": "^3.6.6",
+    "@apollo/client": "^3.6.9",
     "@typescript-eslint/eslint-plugin": "^5.20.0",
     "@typescript-eslint/parser": "^5.20.0",
     "element-cli": "^2.0.4",

--- a/packages/indexer/src/api/index.ts
+++ b/packages/indexer/src/api/index.ts
@@ -62,6 +62,7 @@ app.use('/', router);
     context: {
       prisma: (await getDB()).client,
     },
+    cache: 'bounded',
   });
 
   if (isProduction) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -14,9 +14,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@apollo/client@npm:^3.6.6":
-  version: 3.6.6
-  resolution: "@apollo/client@npm:3.6.6"
+"@apollo/client@npm:^3.6.9":
+  version: 3.6.9
+  resolution: "@apollo/client@npm:3.6.9"
   dependencies:
     "@graphql-typed-document-node/core": ^3.1.1
     "@wry/context": ^0.6.0
@@ -42,7 +42,7 @@ __metadata:
       optional: true
     subscriptions-transport-ws:
       optional: true
-  checksum: 3cf430f406d3f4b5a316f36830a115452f27b7db47e1b7161725603e444332355e5a8fde992c3ec9268b44e8db8030e1ab021f965a186667eaa8af1d144c2beb
+  checksum: a3c037ef3465cb5d736d8495c9c2dcb9741e39d9c102f147b479af1923c5913f710981a311d1098b9969ebe87769b749c22274decb5977ad0619032e7ac2cf26
   languageName: node
   linkType: hard
 
@@ -70,10 +70,83 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@apollo/utils.dropunuseddefinitions@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@apollo/utils.dropunuseddefinitions@npm:1.1.0"
+  peerDependencies:
+    graphql: 14.x || 15.x || 16.x
+  checksum: b66e07086ea65bcb94d84cfd5e6d90d0406c4e7f602c9a5e793c2001273380a4f61c287f60ee1d81d47d49d3a62ef3f0afb8049243540d3021ff445869124094
+  languageName: node
+  linkType: hard
+
+"@apollo/utils.keyvaluecache@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "@apollo/utils.keyvaluecache@npm:1.0.1"
+  dependencies:
+    "@apollo/utils.logger": ^1.0.0
+    lru-cache: ^7.10.1
+  checksum: 1a5dbd2eae0575905e25d471430d431d145b767ee6f5e8efe3ba64ed44208db131f437e36cf17df6623ae6de97a87c4c8691b4a274510b52ab49f6afe9627a3b
+  languageName: node
+  linkType: hard
+
 "@apollo/utils.logger@npm:^1.0.0":
   version: 1.0.0
   resolution: "@apollo/utils.logger@npm:1.0.0"
   checksum: 9be2b269d6d1cf2235c7b49a5edbb36c87589facf79516521df66d0c782709b7301a1365693b6e15d77f482d231bbb0fea4c2ae42faac7068cc4e014ce338c68
+  languageName: node
+  linkType: hard
+
+"@apollo/utils.printwithreducedwhitespace@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@apollo/utils.printwithreducedwhitespace@npm:1.1.0"
+  peerDependencies:
+    graphql: 14.x || 15.x || 16.x
+  checksum: 86536751681c64f35a2d37b0c2f69a39d91ea0e4f0c3c993d9f76fa109f85e9d306e6994bd6e38eef1e4e5b83245125aaa125ecc94e185d90b3255f06a538503
+  languageName: node
+  linkType: hard
+
+"@apollo/utils.removealiases@npm:1.0.0":
+  version: 1.0.0
+  resolution: "@apollo/utils.removealiases@npm:1.0.0"
+  peerDependencies:
+    graphql: 14.x || 15.x || 16.x
+  checksum: fda30ad4ee1fbf012e4289b9963b8b75a102eadbdfa5e558dc923cfc68df42eff6e232dc20c34b7e7563e5aac7ae3781d17919cd8f5eccb90c4225a274b2af93
+  languageName: node
+  linkType: hard
+
+"@apollo/utils.sortast@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@apollo/utils.sortast@npm:1.1.0"
+  dependencies:
+    lodash.sortby: ^4.7.0
+  peerDependencies:
+    graphql: 14.x || 15.x || 16.x
+  checksum: 5ec695d8c91efd82ad75cb3e27662644c71e22be71793908135b38965be6fe1f229c24fd2f4fed1bc1829b84bec2a1f6470817a83c633d95292db7635a625471
+  languageName: node
+  linkType: hard
+
+"@apollo/utils.stripsensitiveliterals@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "@apollo/utils.stripsensitiveliterals@npm:1.2.0"
+  peerDependencies:
+    graphql: 14.x || 15.x || 16.x
+  checksum: 5910186a30be23fac59652d350e83a8a7a53adb9146ed545906f6893ad9c8d380752e679348ee210ae01fa39cc0487692b632e960003dcedc2282bd28de2aa01
+  languageName: node
+  linkType: hard
+
+"@apollo/utils.usagereporting@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "@apollo/utils.usagereporting@npm:1.0.0"
+  dependencies:
+    "@apollo/utils.dropunuseddefinitions": ^1.1.0
+    "@apollo/utils.printwithreducedwhitespace": ^1.1.0
+    "@apollo/utils.removealiases": 1.0.0
+    "@apollo/utils.sortast": ^1.1.0
+    "@apollo/utils.stripsensitiveliterals": ^1.2.0
+    apollo-reporting-protobuf: ^3.3.1
+  peerDependencies:
+    graphql: 14.x || 15.x || 16.x
+  checksum: 9f4d1b8381fc7930619c51ce96580e61e604455e01701de9c822245d3a7583553a0cc4c050450ddf80d8e556682b2ac79ed784c58a8b98b52cf097d344c5d1d8
   languageName: node
   linkType: hard
 
@@ -2171,7 +2244,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@nomad-xyz/indexer@workspace:packages/indexer"
   dependencies:
-    "@apollo/client": ^3.6.6
+    "@apollo/client": ^3.6.9
     "@graphql-tools/schema": ^8.3.5
     "@nomad-xyz/contracts-bridge": 1.0.0-rc.3
     "@nomad-xyz/multi-provider": ^1.0.0-rc.5
@@ -2187,9 +2260,9 @@ __metadata:
     "@types/redis": ^4.0.11
     "@typescript-eslint/eslint-plugin": ^5.20.0
     "@typescript-eslint/parser": ^5.20.0
-    apollo-server: 3.7.0
-    apollo-server-core: 3.7.0
-    apollo-server-express: 3.7.0
+    apollo-server: 3.9.0
+    apollo-server-core: 3.9.0
+    apollo-server-express: 3.9.0
     axios: ^0.26.0
     bunyan: ^1.8.15
     class-validator: ^0.13.2
@@ -3335,7 +3408,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/express-serve-static-core@npm:4.17.28, @types/express-serve-static-core@npm:^4.17.18":
+"@types/express-serve-static-core@npm:4.17.29":
+  version: 4.17.29
+  resolution: "@types/express-serve-static-core@npm:4.17.29"
+  dependencies:
+    "@types/node": "*"
+    "@types/qs": "*"
+    "@types/range-parser": "*"
+  checksum: ec4194dc59276ec6dd906887fc377be0cadf4aaa4d535d9052ab9624937ef2b984a8d9da2c11c96979e21f3d9f78f1da93e767dbcec637f7f13d2e3003151145
+  languageName: node
+  linkType: hard
+
+"@types/express-serve-static-core@npm:^4.17.18":
   version: 4.17.28
   resolution: "@types/express-serve-static-core@npm:4.17.28"
   dependencies:
@@ -4490,13 +4574,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"apollo-datasource@npm:^3.3.1":
-  version: 3.3.1
-  resolution: "apollo-datasource@npm:3.3.1"
+"apollo-datasource@npm:^3.3.2":
+  version: 3.3.2
+  resolution: "apollo-datasource@npm:3.3.2"
   dependencies:
-    apollo-server-caching: ^3.3.0
+    "@apollo/utils.keyvaluecache": ^1.0.1
     apollo-server-env: ^4.2.1
-  checksum: 5085c731afc45ea19198bad1fb59bfce779f5288802037e7681210b408bd3bc531dbe832236a91c72e084bc3ee5a8742440656a90e46b3f3939295159a2f62e2
+  checksum: 70244e792655b357213b92e9dd0e8ca553724857847c9bedb53a1dbf7a92fc0d8b05a60d77203d6c30331599b44c5d7cc5f4d94c934465fa05b146b681ed2293
   languageName: node
   linkType: hard
 
@@ -4509,36 +4593,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"apollo-server-caching@npm:^3.3.0":
-  version: 3.3.0
-  resolution: "apollo-server-caching@npm:3.3.0"
+"apollo-server-core@npm:3.9.0, apollo-server-core@npm:^3.9.0":
+  version: 3.9.0
+  resolution: "apollo-server-core@npm:3.9.0"
   dependencies:
-    lru-cache: ^6.0.0
-  checksum: a5b43025ffb00cb3899fa0584512538747e8afe595ff8a0235caf8469435a03c1edc23fa56893fc77910f032563106872faa7e86a58acf1aed16bf77e9723327
-  languageName: node
-  linkType: hard
-
-"apollo-server-core@npm:3.7.0, apollo-server-core@npm:^3.7.0":
-  version: 3.7.0
-  resolution: "apollo-server-core@npm:3.7.0"
-  dependencies:
+    "@apollo/utils.keyvaluecache": ^1.0.1
     "@apollo/utils.logger": ^1.0.0
+    "@apollo/utils.usagereporting": ^1.0.0
     "@apollographql/apollo-tools": ^0.5.3
     "@apollographql/graphql-playground-html": 1.6.29
     "@graphql-tools/mock": ^8.1.2
     "@graphql-tools/schema": ^8.0.0
     "@josephg/resolvable": ^1.0.0
-    apollo-datasource: ^3.3.1
+    apollo-datasource: ^3.3.2
     apollo-reporting-protobuf: ^3.3.1
-    apollo-server-caching: ^3.3.0
     apollo-server-env: ^4.2.1
     apollo-server-errors: ^3.3.1
-    apollo-server-plugin-base: ^3.5.3
-    apollo-server-types: ^3.5.3
+    apollo-server-plugin-base: ^3.6.1
+    apollo-server-types: ^3.6.1
     async-retry: ^1.2.1
     fast-json-stable-stringify: ^2.1.0
     graphql-tag: ^2.11.0
-    lodash.sortby: ^4.7.0
     loglevel: ^1.6.8
     lru-cache: ^6.0.0
     sha.js: ^2.4.11
@@ -4546,7 +4621,7 @@ __metadata:
     whatwg-mimetype: ^3.0.0
   peerDependencies:
     graphql: ^15.3.0 || ^16.0.0
-  checksum: 94eb354a60a46dfb5afb080ffa92ff32bfa7925191354e08d4724b651c3c8f24db95a75ced784dcdd3169b8655bec35ae32283b196d1c35a2ad85adb3cf74ca9
+  checksum: 161401b7081ff69415999dcfb010d410ef8b1f8ee63368b54dddd0a24b8803b4c269dde0844e0a4fc5963169101f12749d9d9ae3c5cf4f0ac7fdd60b43eda43c
   languageName: node
   linkType: hard
 
@@ -4568,62 +4643,64 @@ __metadata:
   languageName: node
   linkType: hard
 
-"apollo-server-express@npm:3.7.0, apollo-server-express@npm:^3.7.0":
-  version: 3.7.0
-  resolution: "apollo-server-express@npm:3.7.0"
+"apollo-server-express@npm:3.9.0, apollo-server-express@npm:^3.9.0":
+  version: 3.9.0
+  resolution: "apollo-server-express@npm:3.9.0"
   dependencies:
     "@types/accepts": ^1.3.5
     "@types/body-parser": 1.19.2
     "@types/cors": 2.8.12
     "@types/express": 4.17.13
-    "@types/express-serve-static-core": 4.17.28
+    "@types/express-serve-static-core": 4.17.29
     accepts: ^1.3.5
-    apollo-server-core: ^3.7.0
-    apollo-server-types: ^3.5.3
+    apollo-server-core: ^3.9.0
+    apollo-server-types: ^3.6.1
     body-parser: ^1.19.0
     cors: ^2.8.5
     parseurl: ^1.3.3
   peerDependencies:
     express: ^4.17.1
     graphql: ^15.3.0 || ^16.0.0
-  checksum: 0e34647726d36faba4464efc9b2b31670229b092ca7dcdeaf10e9d965231ae7c5b979047ab447defa6f223c4cb45c9b1ff8ac1b3545e5a880dcb450aee2d71b2
+  checksum: 04219816fe72e0852281765766e12393161e514c2b11f2b001dd53a3f238998477511d06229988c7804dcd073eda0702bf9f2c72b555f530d32722cbf56fb687
   languageName: node
   linkType: hard
 
-"apollo-server-plugin-base@npm:^3.5.3":
-  version: 3.5.3
-  resolution: "apollo-server-plugin-base@npm:3.5.3"
+"apollo-server-plugin-base@npm:^3.6.1":
+  version: 3.6.1
+  resolution: "apollo-server-plugin-base@npm:3.6.1"
   dependencies:
-    apollo-server-types: ^3.5.3
+    apollo-server-types: ^3.6.1
   peerDependencies:
     graphql: ^15.3.0 || ^16.0.0
-  checksum: c914d21295fb0bd42f7f9df69ebdd5935b531d867ad905cd71abe22f82a46808493311dcc803294cb0418c4c3be5c28670320cf70ff806f5c0c6ca3de0810e8d
+  checksum: 66932834602e73b2df94057e37a98263990adb75cd76ab6b6d40af56f3e68591d02f3f2859036c9111898840f10ab59f6d06806607b562404deb86704cce386a
   languageName: node
   linkType: hard
 
-"apollo-server-types@npm:^3.5.3":
-  version: 3.5.3
-  resolution: "apollo-server-types@npm:3.5.3"
+"apollo-server-types@npm:^3.6.1":
+  version: 3.6.1
+  resolution: "apollo-server-types@npm:3.6.1"
   dependencies:
+    "@apollo/utils.keyvaluecache": ^1.0.1
+    "@apollo/utils.logger": ^1.0.0
     apollo-reporting-protobuf: ^3.3.1
-    apollo-server-caching: ^3.3.0
     apollo-server-env: ^4.2.1
   peerDependencies:
     graphql: ^15.3.0 || ^16.0.0
-  checksum: 5b8ec05b2a80f7acddb5de4d558ef4927425edb171b49293cd61300b72dafbe335d1d10225c52188b135609d51b8f623fe5362817550ce0a6f470515dfeff564
+  checksum: b637c7d040f3c8bc1121918b441180999ea71e142e2ab9626e341015905d0b89be630bdf848fb0a4f39be71f12ac702f49e5b060eb0f13314f0a9e5183a759ab
   languageName: node
   linkType: hard
 
-"apollo-server@npm:3.7.0":
-  version: 3.7.0
-  resolution: "apollo-server@npm:3.7.0"
+"apollo-server@npm:3.9.0":
+  version: 3.9.0
+  resolution: "apollo-server@npm:3.9.0"
   dependencies:
-    apollo-server-core: ^3.7.0
-    apollo-server-express: ^3.7.0
+    "@types/express": 4.17.13
+    apollo-server-core: ^3.9.0
+    apollo-server-express: ^3.9.0
     express: ^4.17.1
   peerDependencies:
     graphql: ^15.3.0 || ^16.0.0
-  checksum: a922fc29694d5105c97f802995ac56b3546dc7af290b886e46de3d90a2b42a740a1c70b6ca06b859fd68d852c7e56a4875423f7ec94828fede390d390628dec2
+  checksum: 11fb36801800da2284857f3fb490eb141536a9cf3b6a3e0506a8f46f062d4384f951652c4b4229fb85c06c108ee9b68328ff55cd74b9f3254a4359551a2ef1b4
   languageName: node
   linkType: hard
 
@@ -14649,6 +14726,13 @@ __metadata:
   dependencies:
     yallist: ^4.0.0
   checksum: f97f499f898f23e4585742138a22f22526254fdba6d75d41a1c2526b3b6cc5747ef59c5612ba7375f42aca4f8461950e925ba08c991ead0651b4918b7c978297
+  languageName: node
+  linkType: hard
+
+"lru-cache@npm:^7.10.1":
+  version: 7.10.2
+  resolution: "lru-cache@npm:7.10.2"
+  checksum: b8f98064c981ce98e2a3b82903726dd28d842f54b7f53e1d6029c6836546243d4157b8495a405c062209715c612050150bdf30b5fa8200d5a3559fb0fd4072c1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Motivation

Warning message that appeared when starting apollo server

```
indexer-api-1       | Persisted queries are enabled and are using an unbounded cache. Your server is vulnerable to denial of service attacks via memory exhaustion. Set `cache: "bounded"` or `persistedQueries: false` in your ApolloServer constructor, or see https://go.apollo.dev/s/cache-backends for other alternatives.
```

## Solution

Use recommended apollo server cache setting (`bounded`)

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Updated Documentation
- [x] Updated CHANGELOG.md for the appropriate package
