### PR TITLE
feat: Fix long CI due to accumulator-cli

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,6 +14,21 @@ jobs:
           yarn install
       - run: |
           yarn lint
+      - name: Get latest accumulator-cli version
+        id: acli-version
+        run: |
+          echo "::set-output name=ACLI_HASH::$(curl https://api.github.com/repos/odyslam/accumulator-cli/git/refs/heads/master | jq '.object.sha' -r)"
+      - name: Cache Accumulator-cli
+        id: cache-acli
+        uses: actions/cache@v3
+        with:
+          path: scripts/accumulator-cli
+          key: ${{ runner.os }}-${{ steps.acli-version.outputs.ACLI_HASH }}-accumulator-cli
+      - uses: actions-rs/toolchain@v1
+        if: steps.cache-acli.outputs.cache-hit != 'true'
+        with:
+          profile: minimal
+          toolchain: stable
       - run: |
           yarn build:accumulator-cli
       - run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,7 @@ discussion.
 Nomad strives to create an inclusive and welcoming development environment.
 Generally, we follow the
 [Rust Code of Conduct](https://www.rust-lang.org/policies/code-of-conduct).
+
 This is the _minimum_ expected behavior of our employees and outside
 contributors. Violations of this code of conduct should be reported to the team
 directly via [j@nomad.xyz](mailto:j@nomad.xyz).


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below. Bug fixes and new features should include tests.

New contributors should read the contributors guide:
https://github.com/nomad-xyz/monorepo/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building
the documentation.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Add cache step. 

If no newer version of the cli is released, it takes ~1s. 

If there are newer versions (should be very rare), it will build and then cache.

## PR Checklist

- [x] Added Tests
- [x] Updated Documentation
- [ ] Updated CHANGELOG.md for the appropriate package
