### PR TITLE
refactor: change message status from enum to tagged union

### DIFF
--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### Unreleased
 
+- (major) refactor: change message status to a tagged union instead of an enum,
+  added the root to the `proven` message status
+
 ### 2.1.0-rc.0
 
 - upgrade: contracts

--- a/packages/sdk/src/messages/NomadMessage.ts
+++ b/packages/sdk/src/messages/NomadMessage.ts
@@ -494,7 +494,7 @@ export class NomadMessage<T extends NomadContext> {
    */
   async delivered(): Promise<boolean> {
     const { status } = await this.replicaStatus();
-    return status === 'processed';
+    return status === ReplicaStatusNames.Processed;
   }
 
   /**

--- a/packages/sdk/src/messages/NomadMessage.ts
+++ b/packages/sdk/src/messages/NomadMessage.ts
@@ -48,11 +48,23 @@ export enum MessageStatus {
   Processed = 3,
 }
 
-export enum ReplicaMessageStatus {
-  None = 0,
-  Proven,
-  Processed,
-}
+type ReplicaMessageStatusNone = {
+  status: 'none';
+};
+
+type ReplicaMessageStatusProcess = {
+  status: 'processed';
+};
+
+type ReplicaMessageStatusProven = {
+  status: 'proven';
+  root: string;
+};
+
+export type ReplicaMessageStatus =
+  | ReplicaMessageStatusNone
+  | ReplicaMessageStatusProcess
+  | ReplicaMessageStatusProven;
 
 export type EventCache = {
   homeUpdate?: AnnotatedUpdate;
@@ -450,13 +462,22 @@ export class NomadMessage<T extends NomadContext> {
   async replicaStatus(): Promise<ReplicaMessageStatus> {
     // backwards compatibility. Older replica versions returned a number,
     // newer versions return a hash
-    const root = (await this.replica.messages(this.leaf)) as string | number;
-    if (root === ethers.constants.HashZero || root === 0)
-      return ReplicaMessageStatus.None;
-    if (root === `0x${'00'.repeat(31)}02` || root === 2)
-      return ReplicaMessageStatus.Processed;
+    let root: string | number = await this.replica.messages(this.leaf);
+    root = root as string | number;
 
-    return ReplicaMessageStatus.Proven;
+    // case one: root is 0
+    if (root === ethers.constants.HashZero || root === 0)
+      return { status: 'none' };
+
+    // case two: root is 2
+    const legacyProcessed = `0x${'00'.repeat(31)}02`;
+    if (root === legacyProcessed || root === 2) return { status: 'processed' };
+
+    // case 3: root is proven. Could be either the root, or the legacy proven
+    // status
+    const legacyProven = `0x${'00'.repeat(31)}01`;
+    if (typeof root === 'number') root = legacyProven;
+    return { status: 'proven', root: root as string };
   }
 
   /**
@@ -465,8 +486,8 @@ export class NomadMessage<T extends NomadContext> {
    * @returns true if processed, else false.
    */
   async delivered(): Promise<boolean> {
-    const status = await this.replicaStatus();
-    return status === ReplicaMessageStatus.Processed;
+    const { status } = await this.replicaStatus();
+    return status === 'processed';
   }
 
   /**

--- a/packages/sdk/src/messages/NomadMessage.ts
+++ b/packages/sdk/src/messages/NomadMessage.ts
@@ -48,16 +48,22 @@ export enum MessageStatus {
   Processed = 3,
 }
 
+export enum ReplicaStatusNames {
+  None = 'none',
+  Proven = 'proven',
+  Processed = 'processed',
+}
+
 type ReplicaMessageStatusNone = {
-  status: 'none';
+  status: ReplicaStatusNames.None;
 };
 
 type ReplicaMessageStatusProcess = {
-  status: 'processed';
+  status: ReplicaStatusNames.Processed;
 };
 
 type ReplicaMessageStatusProven = {
-  status: 'proven';
+  status: ReplicaStatusNames.Proven;
   root: string;
 };
 
@@ -467,17 +473,18 @@ export class NomadMessage<T extends NomadContext> {
 
     // case one: root is 0
     if (root === ethers.constants.HashZero || root === 0)
-      return { status: 'none' };
+      return { status: ReplicaStatusNames.None };
 
     // case two: root is 2
     const legacyProcessed = `0x${'00'.repeat(31)}02`;
-    if (root === legacyProcessed || root === 2) return { status: 'processed' };
+    if (root === legacyProcessed || root === 2)
+      return { status: ReplicaStatusNames.Processed };
 
     // case 3: root is proven. Could be either the root, or the legacy proven
     // status
     const legacyProven = `0x${'00'.repeat(31)}01`;
     if (typeof root === 'number') root = legacyProven;
-    return { status: 'proven', root: root as string };
+    return { status: ReplicaStatusNames.Proven, root: root as string };
   }
 
   /**


### PR DESCRIPTION
## Motivation

New protocol versions return the root a message was proven under. We should capture and expose this in the TS SDK

## Solution

Change MessageStatus from an enum to a union with discrimanator.

This is an API-breaking change (major version bump) however, given that we are in RCs this is still a candidate for the current non-RC release (i.e. we don't need to bump to 3.0.0 as 2.0.0 is not finalized)

## PR Checklist

- [ ] Added Tests
- [ ] Updated Documentation
- [x] Updated CHANGELOG.md for the appropriate package
