### PR TITLE
feat: add connext reconciliation + sending

### DIFF
--- a/packages/contracts-bridge/contracts/BridgeMessage.sol
+++ b/packages/contracts-bridge/contracts/BridgeMessage.sol
@@ -20,7 +20,8 @@ library BridgeMessage {
         TokenId, // 1
         Message, // 2
         Transfer, // 3
-        FastTransfer // 4
+        FastTransfer, // 4
+        ConnextTransfer // 5
     }
 
     // ============ Structs ============
@@ -37,7 +38,7 @@ library BridgeMessage {
 
     uint256 private constant TOKEN_ID_LEN = 36; // 4 bytes domain + 32 bytes id
     uint256 private constant IDENTIFIER_LEN = 1;
-    uint256 private constant TRANSFER_LEN = 97; // 1 byte identifier + 32 bytes recipient + 32 bytes amount + 32 bytes detailsHash
+    uint256 private constant TRANSFER_LEN = 129; // 1 byte identifier + 32 bytes recipient + 32 bytes amount + 32 bytes detailsHash + 32 bytes externalId
 
     // ============ Modifiers ============
 
@@ -131,21 +132,31 @@ library BridgeMessage {
     }
 
     /**
+     * @notice Checks that the message is of type ConnextTransfer
+     * @param _action The message
+     * @return True if the message is of type ConnextTransfer
+     */
+    function isConnextTransfer(bytes29 _action) internal pure returns (bool) {
+        return isType(_action, Types.ConnextTransfer);
+    }
+
+
+    /**
      * @notice Formats Transfer
      * @param _to The recipient address as bytes32
      * @param _amnt The transfer amount
      * @param _detailsHash The hash of the token name, symbol, and decimals
+     * @param _externalId The external identifier of the transfer
      * @return
      */
     function formatTransfer(
         bytes32 _to,
         uint256 _amnt,
-        bytes32 _detailsHash
+        bytes32 _detailsHash,
+        bytes32 _externalId
     ) internal pure returns (bytes29) {
-        return
-            abi.encodePacked(Types.Transfer, _to, _amnt, _detailsHash).ref(0).castTo(
-                uint40(Types.Transfer)
-            );
+        Types transferType = _externalId == bytes32(0) ? Types.Transfer : Types.ConnextTransfer;
+        return abi.encodePacked(transferType, _to, _amnt, _detailsHash, _externalId).ref(0).castTo(uint40(transferType));
     }
 
     /**
@@ -340,6 +351,16 @@ library BridgeMessage {
     {
         // before = 1 byte identifier + 32 bytes ID + 32 bytes amount = 65 bytes
         return _transferAction.index(65, 32);
+    }
+
+    /**
+     * @notice Retrieves the externalId from a Transfer
+     * @param _transferAction The message
+     * @return The external id
+     */
+    function externalId(bytes29 _transferAction) internal pure returns (bytes32) {
+        // before = 1 byte identifier
+        return _transferAction.index(97, 32);
     }
 
     /**

--- a/packages/contracts-bridge/contracts/BridgeRouter.sol
+++ b/packages/contracts-bridge/contracts/BridgeRouter.sol
@@ -88,11 +88,10 @@ contract BridgeRouter is Version0, Router {
 
     // ======== Initializer ========
 
-    function initialize(address _tokenRegistry, address _xAppConnectionManager, address _connext)
+    function initialize(address _tokenRegistry, address _xAppConnectionManager)
         public
         initializer
     {
-        connext = IConnext(_connext);
         tokenRegistry = ITokenRegistry(_tokenRegistry);
         __XAppConnectionClient_initialize(_xAppConnectionManager);
     }
@@ -208,8 +207,22 @@ contract BridgeRouter is Version0, Router {
         IBridgeToken(_currentRepr).mint(msg.sender, _bal);
     }
 
+    // ======== External: Connext =========
+
+    /**
+     * @notice Allows the admin to set the Connext reference
+     * @param _connext Address of the connext contract
+     */
+    function setConnext(address _connext) external onlyOwner {
+        connext = IConnext(_connext);
+    }
+
     // ============ Internal: Send ============
 
+    /**
+     * @notice Internal function to send tokens.
+     * @dev Burns tokens if needed, and constructs the message to dispatch
+     */
     function _send(
         address _token,
         uint256 _amount,

--- a/packages/contracts-bridge/contracts/BridgeRouter.sol
+++ b/packages/contracts-bridge/contracts/BridgeRouter.sol
@@ -43,7 +43,7 @@ contract BridgeRouter is Version0, Router {
     // ============ Upgrade Gap ============
 
     // gap for upgrade safety
-    uint256[49] private __GAP;
+    uint256[48] private __GAP;
 
     // ======== Events =========
 

--- a/packages/contracts-bridge/contracts/BridgeRouter.sol
+++ b/packages/contracts-bridge/contracts/BridgeRouter.sol
@@ -251,7 +251,7 @@ contract BridgeRouter is Version0, Router {
             _detailsHash = _t.detailsHash();
         }
         // format Transfer Tokens action
-        bytes29 _action = BridgeMessage.formatTransfer(_recipient, _amount, _detailsHash, _externalId);
+        bytes29 _action = _externalId == bytes32(0) ? BridgeMessage.formatTransfer(_recipient, _amount, _detailsHash) : BridgeMessage.formatConnextTransfer(_externalId, _amount, _detailsHash);
         // get the tokenID
         (uint32 _domain, bytes32 _id) = tokenRegistry.getTokenId(_token);
         bytes29 _tokenId = BridgeMessage.formatTokenId(_domain, _id);

--- a/packages/contracts-bridge/contracts/BridgeRouter.sol
+++ b/packages/contracts-bridge/contracts/BridgeRouter.sol
@@ -239,16 +239,16 @@ contract BridgeRouter is Version0, Router {
         bytes32 _detailsHash;
         // remove tokens from circulation on this chain
         if (tokenRegistry.isLocalOrigin(_token)) {
-        // if the token originates on this chain,
-        // hold the tokens in escrow in the Router
-        IERC20(_token).safeTransferFrom(msg.sender, address(this), _amount);
-        // query token contract for details and calculate detailsHash
-        _detailsHash = BridgeMessage.getDetailsHash(_t.name(), _t.symbol(), _t.decimals());
+            // if the token originates on this chain,
+            // hold the tokens in escrow in the Router
+            IERC20(_token).safeTransferFrom(msg.sender, address(this), _amount);
+            // query token contract for details and calculate detailsHash
+            _detailsHash = BridgeMessage.getDetailsHash(_t.name(), _t.symbol(), _t.decimals());
         } else {
-        // if the token originates on a remote chain,
-        // burn the representation tokens on this chain
-        _t.burn(msg.sender, _amount);
-        _detailsHash = _t.detailsHash();
+            // if the token originates on a remote chain,
+            // burn the representation tokens on this chain
+            _t.burn(msg.sender, _amount);
+            _detailsHash = _t.detailsHash();
         }
         // format Transfer Tokens action
         bytes29 _action = BridgeMessage.formatTransfer(_recipient, _amount, _detailsHash, _externalId);

--- a/packages/contracts-bridge/contracts/BridgeRouter.sol
+++ b/packages/contracts-bridge/contracts/BridgeRouter.sol
@@ -5,6 +5,7 @@ pragma solidity 0.7.6;
 import {BridgeMessage} from "./BridgeMessage.sol";
 import {IBridgeToken} from "./interfaces/IBridgeToken.sol";
 import {ITokenRegistry} from "./interfaces/ITokenRegistry.sol";
+import {IConnext} from "./interfaces/IConnext.sol";
 // ============ External Imports ============
 import {XAppConnectionClient} from "@nomad-xyz/contracts-router/contracts/XAppConnectionClient.sol";
 import {Router} from "@nomad-xyz/contracts-router/contracts/Router.sol";
@@ -36,6 +37,8 @@ contract BridgeRouter is Version0, Router {
     ITokenRegistry public tokenRegistry;
     // token transfer prefill ID => LP that pre-filled message to provide fast liquidity
     mapping(bytes32 => address) public liquidityProvider;
+    // reference to connext contract on this domain
+    IConnext public connext;
 
     // ============ Upgrade Gap ============
 
@@ -85,10 +88,11 @@ contract BridgeRouter is Version0, Router {
 
     // ======== Initializer ========
 
-    function initialize(address _tokenRegistry, address _xAppConnectionManager)
+    function initialize(address _tokenRegistry, address _xAppConnectionManager, address _connext)
         public
         initializer
     {
+        connext = IConnext(_connext);
         tokenRegistry = ITokenRegistry(_tokenRegistry);
         __XAppConnectionClient_initialize(_xAppConnectionManager);
     }
@@ -114,9 +118,11 @@ contract BridgeRouter is Version0, Router {
         bytes29 _action = _msg.action();
         // handle message based on the intended action
         if (_action.isTransfer()) {
-            _handleTransfer(_origin, _nonce, _tokenId, _action, false);
+            _handleTransfer(_origin, _nonce, _tokenId, _action, false, false);
         } else if (_action.isFastTransfer()) {
-            _handleTransfer(_origin, _nonce, _tokenId, _action, true);
+            _handleTransfer(_origin, _nonce, _tokenId, _action, true, false);
+        } else if (_action.isConnextTransfer()) {
+            _handleTransfer(_origin, _nonce, _tokenId, _action, false, true);
         } else {
             require(false, "!valid action");
         }
@@ -138,54 +144,29 @@ contract BridgeRouter is Version0, Router {
         bytes32 _recipient,
         bool /*_enableFast - deprecated field, left argument for backwards compatibility */
     ) external {
-        require(_amount > 0, "!amnt");
         require(_recipient != bytes32(0), "!recip");
-        // get remote BridgeRouter address; revert if not found
-        bytes32 _remote = _mustHaveRemote(_destination);
-        // Setup vars used in both if branches
-        IBridgeToken _t = IBridgeToken(_token);
-        bytes32 _detailsHash;
-        // remove tokens from circulation on this chain
-        if (tokenRegistry.isLocalOrigin(_token)) {
-            // if the token originates on this chain,
-            // hold the tokens in escrow in the Router
-            IERC20(_token).safeTransferFrom(msg.sender, address(this), _amount);
-            // query token contract for details and calculate detailsHash
-            _detailsHash = BridgeMessage.getDetailsHash(
-                _t.name(),
-                _t.symbol(),
-                _t.decimals()
-            );
-        } else {
-            // if the token originates on a remote chain,
-            // burn the representation tokens on this chain
-            _t.burn(msg.sender, _amount);
-            _detailsHash = _t.detailsHash();
-        }
-        // format Transfer Tokens action
-        bytes29 _action = BridgeMessage.formatTransfer(
-            _recipient,
-            _amount,
-            _detailsHash
-        );
-        // get the tokenID
-        (uint32 _domain, bytes32 _id) = tokenRegistry.getTokenId(_token);
-        bytes29 _tokenId = BridgeMessage.formatTokenId(_domain, _id);
-        // send message to remote chain via Nomad
-        Home(xAppConnectionManager.home()).dispatch(
-            _destination,
-            _remote,
-            BridgeMessage.formatMessage(_tokenId, _action)
-        );
-        // emit Send event to record token sender
-        emit Send(
-            _token,
-            msg.sender,
-            _destination,
-            _recipient,
-            _amount,
-            false
-        );
+        _send(_token, _amount, _destination, _recipient, bytes32(0));
+    }
+
+    /**
+     * @notice Send tokens to connext on a remote chain
+     * @param _token The token address
+     * @param _amount The token amount
+     * @param _destination The destination domain
+     * @param _externalId The external identifier
+     */
+    function xsend(
+        address _token,
+        uint256 _amount,
+        uint32 _destination,
+        bytes32 _externalId
+    ) external {
+        require(msg.sender == address(connext), "!connext");
+        require(_externalId != bytes32(0), "!id");
+        // NOTE: set recipient as bytes32(0) to avoid storing a mapping of domain => connext
+        // addresses. instead, each router should store a reference to their local connext and
+        // assign that as the recipient on `handle`
+        _send(_token, _amount, _destination, bytes32(0), _externalId);
     }
 
     // ======== External: Custom Tokens =========
@@ -227,6 +208,46 @@ contract BridgeRouter is Version0, Router {
         IBridgeToken(_currentRepr).mint(msg.sender, _bal);
     }
 
+    // ============ Internal: Send ============
+
+    function _send(
+        address _token,
+        uint256 _amount,
+        uint32 _destination,
+        bytes32 _recipient,
+        bytes32 _externalId
+    ) internal {
+        require(_amount > 0, "!amnt");
+        // NOTE: in xsend _externalId != bytes32(0)
+        // get remote BridgeRouter address; revert if not found
+        bytes32 _remote = _mustHaveRemote(_destination);
+        // Setup vars used in both if branches
+        IBridgeToken _t = IBridgeToken(_token);
+        bytes32 _detailsHash;
+        // remove tokens from circulation on this chain
+        if (tokenRegistry.isLocalOrigin(_token)) {
+        // if the token originates on this chain,
+        // hold the tokens in escrow in the Router
+        IERC20(_token).safeTransferFrom(msg.sender, address(this), _amount);
+        // query token contract for details and calculate detailsHash
+        _detailsHash = BridgeMessage.getDetailsHash(_t.name(), _t.symbol(), _t.decimals());
+        } else {
+        // if the token originates on a remote chain,
+        // burn the representation tokens on this chain
+        _t.burn(msg.sender, _amount);
+        _detailsHash = _t.detailsHash();
+        }
+        // format Transfer Tokens action
+        bytes29 _action = BridgeMessage.formatTransfer(_recipient, _amount, _detailsHash, _externalId);
+        // get the tokenID
+        (uint32 _domain, bytes32 _id) = tokenRegistry.getTokenId(_token);
+        bytes29 _tokenId = BridgeMessage.formatTokenId(_domain, _id);
+        // send message to remote chain via Nomad
+        Home(xAppConnectionManager.home()).dispatch(_destination, _remote, BridgeMessage.formatMessage(_tokenId, _action));
+        // emit Send event to record token sender
+        emit Send(_token, msg.sender, _destination, _recipient, _amount, false);
+    }
+
     // ============ Internal: Handle ============
 
     /**
@@ -240,38 +261,38 @@ contract BridgeRouter is Version0, Router {
      * @param _tokenId The token ID
      * @param _action The action
      * @param _fastEnabled True if fast liquidity was enabled, False otherwise
+     * @param _isConnext True if is connext transfer, False otherwise
      */
     function _handleTransfer(
         uint32 _origin,
         uint32 _nonce,
         bytes29 _tokenId,
         bytes29 _action,
-        bool _fastEnabled
+        bool _fastEnabled,
+        bool _isConnext
     ) internal {
         // get the token contract for the given tokenId on this chain;
         // (if the token is of remote origin and there is
         // no existing representation token contract, the TokenRegistry will
         // deploy a new one)
-        address _token = tokenRegistry.ensureLocalToken(
-            _tokenId.domain(),
-            _tokenId.id()
-        );
+        bytes32 _canonicalId = _tokenId.id();
+        uint32 _canonicalDomain = _tokenId.domain();
+        address _token = tokenRegistry.ensureLocalToken(_canonicalDomain, _canonicalId);
         // load the original recipient of the tokens
         address _recipient = _action.evmRecipient();
+        bytes32 _externalId;
         if (_fastEnabled) {
             // If an LP has prefilled this token transfer,
             // send the tokens to the LP instead of the recipient
-            bytes32 _id = BridgeMessage.getPreFillId(
-                _origin,
-                _nonce,
-                _tokenId,
-                _action
-            );
+            bytes32 _id = BridgeMessage.getPreFillId(_origin, _nonce, _tokenId, _action);
             address _lp = liquidityProvider[_id];
             if (_lp != address(0)) {
                 _recipient = _lp;
                 delete liquidityProvider[_id];
             }
+        } else if (_isConnext) {
+            _recipient = address(connext);
+            _externalId = _action.externalId();
         }
         // load amount once
         uint256 _amount = _action.amnt();
@@ -290,15 +311,13 @@ contract BridgeRouter is Version0, Router {
             IBridgeToken(_token).setDetailsHash(_action.detailsHash());
         }
         // dust the recipient if appropriate
-        _dust(_recipient);
+        if (_isConnext) {
+            connext.reconcile(_externalId, _amount, _canonicalId, _canonicalDomain, _token);
+        } else {
+            _dust(_recipient);
+        }
         // emit Receive event
-        emit Receive(
-            _originAndNonce(_origin, _nonce),
-            _token,
-            _recipient,
-            address(0),
-            _amount
-        );
+        emit Receive(_originAndNonce(_origin, _nonce), _token, _recipient, address(0), _amount);
     }
 
     // ============ Internal: Dust with Gas ============

--- a/packages/contracts-bridge/contracts/interfaces/IConnext.sol
+++ b/packages/contracts-bridge/contracts/interfaces/IConnext.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity 0.7.6;
+
+interface IConnext {
+  function reconcile(
+    bytes32 transferId,
+    uint256 amount,
+    bytes32 canonicalId,
+    uint32 canonicalDomain,
+    address localToken
+  ) external;
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below. Bug fixes and new features should include tests.

New contributors should read the contributors guide:
https://github.com/nomad-xyz/monorepo/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building
the documentation.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Allow Connext to be integrated directly into the `BridgeRouter` instead of migration.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

- Add a reference to `Connext` to the `BridgeRouter`
- Add a `bytes32 _externalId` to the `BridgeMessage`. This identifier will only be set for Connext transfers
- Add a new `Type` for `BridgeMessage` of `ConnextTransfer`, which will include a non-zero identifier, and empty recipient
- Add `xsend` method to be used by Connext. This method acts exactly like `send`, but will create a `ConnextTransfer` message (recipient will be destination domain Connext contract, which is stored on the `BridgeRouter` so is empty within the message and there is a 32 byte identifier).
- On `handle` if it is a `ConnextTransfer` message, it will mint funds to the stored Connext contract and call `reconcile` with the external id and other token information

## PR Checklist

- [ ] Added Tests
- [ ] Updated Documentation
- [ ] Updated CHANGELOG.md for the appropriate package
