### PR TITLE
feat: add forge-std submodule for testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 node_modules/
-lib/
 yarn-error.log
 **/tsconfig.tsbuildinfo
 dist/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "lib/forge-std"]
+	path = lib/forge-std
+	url = https://github.com/foundry-rs/forge-std


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below. Bug fixes and new features should include tests.

New contributors should read the contributors guide:
https://github.com/nomad-xyz/monorepo/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building
the documentation.
-->

## Motivation
the `forge-std` submodule was missing causing solc import errors:

```console
Compiler run failed
error[6275]: packages/contracts-core/contracts/test/NomadBase.t.sol:7:1: ParserError: Source "forge-std/console.sol" not found: File outside of allowed directories.
import {console} from "forge-std/console.sol";
```
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
add `forge-std` as submodule via `forge install foundry-rs/forge-std`

**Note*** I had to unignore the `lib` folder (default dir for submodule imports), not sure if this causes side-effects with yarn/javascript builds

if so I can move this to another dir

`FOUNDRY_PROFILE=core forge build ` now works
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Updated Documentation
- [ ] Updated CHANGELOG.md for the appropriate package
