### PR TITLE
chore: fix compiler warnings

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -13,7 +13,7 @@ bytecode_hash = "none"        # For deterministic code
 block_timestamp = 1622400000  # Timestamp for tests (non-zero)
 
 # silence warning about ignored constructor visibility in OZ dependency
-ignored_error_codes = [2462]
+ignored_error_codes = [2462, 5878]
 
 
 [core]

--- a/foundry.toml
+++ b/foundry.toml
@@ -12,7 +12,9 @@ verbosity = 3                 # The verbosity of tests
 bytecode_hash = "none"        # For deterministic code
 block_timestamp = 1622400000  # Timestamp for tests (non-zero)
 
-# silence warning about ignored constructor visibility in OZ dependency
+# silence warnings
+# 2462 - ignored constructor visibility in OZ dependency
+# 5868 - Failure condition of 'send' ignored in bridge
 ignored_error_codes = [2462, 5878]
 
 

--- a/foundry.toml
+++ b/foundry.toml
@@ -12,6 +12,10 @@ verbosity = 3                 # The verbosity of tests
 bytecode_hash = "none"        # For deterministic code
 block_timestamp = 1622400000  # Timestamp for tests (non-zero)
 
+# silence warning about ignored constructor visibility in OZ dependency
+ignored_error_codes = [2462]
+
+
 [core]
 src = 'packages/contracts-core/contracts'
 test = 'packages/contracts-core/contracts/foundry-tests'

--- a/packages/contracts-core/contracts/test/Home.t.sol
+++ b/packages/contracts-core/contracts/test/Home.t.sol
@@ -79,15 +79,6 @@ contract HomeTest is NomadTestWithUpdaterManager {
         bytes32 recipient = bytes32(uint256(uint160(vm.addr(1505))));
         address sender = vm.addr(1555);
         bytes memory messageBody = new bytes(2 * 2**10 + 1);
-        uint32 nonce = home.nonces(remoteDomain);
-        bytes memory message = Message.formatMessage(
-            homeDomain,
-            bytes32(uint256(uint160(sender))),
-            nonce,
-            remoteDomain,
-            recipient,
-            messageBody
-        );
         vm.prank(sender);
         vm.expectRevert("msg too long");
         home.dispatch(remoteDomain, recipient, messageBody);

--- a/packages/contracts-core/contracts/test/Replica.t.sol
+++ b/packages/contracts-core/contracts/test/Replica.t.sol
@@ -229,7 +229,7 @@ contract ReplicaTest is ReplicaHandlers {
         );
         (
             bytes32 root,
-            bytes32 leaf,
+            ,
             uint256 index,
             bytes32[32] memory proof
         ) = merkleTest.getProof(message);
@@ -530,9 +530,9 @@ contract ReplicaTest is ReplicaHandlers {
         );
         (
             bytes32 newRoot,
-            bytes32 leaf,
-            uint256 index,
-            bytes32[32] memory proof
+            ,
+            ,
+
         ) = merkleTest.getProof(message);
         bytes32 oldRoot = committedRoot;
         bytes memory sig = signRemoteUpdate(updaterPK, oldRoot, newRoot);

--- a/packages/contracts-core/contracts/test/utils/MerkleTest.sol
+++ b/packages/contracts-core/contracts/test/utils/MerkleTest.sol
@@ -18,8 +18,6 @@ contract MerkleTest is Test {
             bytes32[32] memory
         )
     {
-        // Hash the message
-        bytes32 hash = keccak256(message);
         string[] memory input = new string[](7);
         input[0] = "yarn";
         input[1] = "gen-proof";


### PR DESCRIPTION

## Motivation

less meaningless terminal output on builds

## Solution

Remove unused variables from tests, 
Adds a foundry ignore for a spurious warn re: constructor visibility
Add a foundry ignore for an intentional departure from compiler recommendation

- unfortunately, this won't silence hardhat's compilation warnings

## PR Checklist

- [n/a] Added Tests
- [n/a] Updated Documentation
- [n/a] Updated CHANGELOG.md for the appropriate package
