### PR TITLE
fix: pin hardhat-packager to minor; remove from deploy

### DIFF
--- a/packages/contracts-bridge/package.json
+++ b/packages/contracts-bridge/package.json
@@ -46,6 +46,7 @@
     "ethers": "^5.4.4",
     "hardhat": "^2.6.0",
     "hardhat-gas-reporter": "^1.0.4",
+    "hardhat-packager": "~1.2.1",
     "prettier": "^2.2.1",
     "prettier-plugin-solidity": "^1.0.0-beta.5",
     "solhint": "^3.3.2",

--- a/packages/contracts-core/package.json
+++ b/packages/contracts-core/package.json
@@ -50,6 +50,7 @@
     "ethers": "^5.4.4",
     "hardhat": "^2.8.3",
     "hardhat-gas-reporter": "^1.0.4",
+    "hardhat-packager": "~1.2.1",
     "prettier": "^2.2.1",
     "prettier-plugin-solidity": "^1.0.0-beta.5",
     "solhint": "^3.3.2",

--- a/packages/contracts-router/package.json
+++ b/packages/contracts-router/package.json
@@ -45,6 +45,7 @@
     "ethers": "^5.4.4",
     "hardhat": "^2.6.0",
     "hardhat-gas-reporter": "^1.0.4",
+    "hardhat-packager": "~1.2.1",
     "prettier": "^2.2.1",
     "prettier-plugin-solidity": "^1.0.0-beta.5",
     "solhint": "^3.3.2",

--- a/packages/deploy/package.json
+++ b/packages/deploy/package.json
@@ -40,7 +40,6 @@
     "eslint": "^7.32.0",
     "eslint-config-prettier": "^8.3.0",
     "ethers": "^5.5.1",
-    "hardhat-packager": "^1.2.1",
     "prettier": "^2.3.1",
     "ts-mocha": "^9.0.2",
     "ts-node": "^10.1.0",


### PR DESCRIPTION
Fixes build issue that was observed in the #348 PR and had to do with incorrect dependency versions