### PR TITLE
Keymaster: Ignore agents for particular networks

### DIFF
--- a/packages/keymaster/CHANGELOG.md
+++ b/packages/keymaster/CHANGELOG.md
@@ -5,3 +5,4 @@
 - New keymaster
 - Can use either KMS or private key signer to fund agents
 - Ethers.js provider which has retry logic and observability through prometheus
+- Can ignore agents from remote networks, like processors, and can ignore local ones like updater or kathy

--- a/packages/keymaster/package.json
+++ b/packages/keymaster/package.json
@@ -17,7 +17,7 @@
     "bunyan": "^1.8.15",
     "decimal.js": "^10.3.1",
     "dotenv": "^16.0.1",
-    "ethers": "^5.6.8",
+    "ethers": "^5.6.9",
     "express": "^4.18.1",
     "keccak": "^3.0.2",
     "prom-client": "^14.0.1",

--- a/packages/keymaster/src/account.ts
+++ b/packages/keymaster/src/account.ts
@@ -17,6 +17,13 @@ dotenv.config();
 
 const prettyPrint = process.env.PRETTY_PRINT === "true";
 
+const hardcodedGasLimits: Record<string, ethers.BigNumberish> = {
+  "bsctestnet": 30000,
+  "arbitrumrinkeby": 600000,
+  "optimismkovan": 30000,
+  "optimismgoerli": 30000,
+};
+
 export abstract class Accountable {
   name: string;
   _address?: string;
@@ -353,7 +360,8 @@ export class Bank extends Accountable {
       `Paying from signer of a bank`
     );
 
-    const sent = await this.signer.sendTransaction({ to, value });
+    const gasLimit = hardcodedGasLimits[this.home.name]
+    const sent = await this.signer.sendTransaction({ to, value, gasLimit });
 
     let receipt;
 

--- a/packages/keymaster/src/account.ts
+++ b/packages/keymaster/src/account.ts
@@ -471,7 +471,7 @@ export class Network {
       (acc, v) => acc.add(v),
       ethers.BigNumber.from("0")
     );
-    
+
     // Temporary hardcode value, so that we don't get much noise when currently we don't want to put 26 eth into the bank
     // TODO: fix strategy
     // this.bank._threshold = threshold;
@@ -553,7 +553,7 @@ export class Network {
                 bankThreshold.sub(bankBalance)
               )} currency. Has ${formatEther(bankBalance)} out of ${formatEther(
                 bankThreshold
-              )}`
+              )}. Address: ${bankAddress}`
             )
           );
       } else {

--- a/packages/keymaster/src/account.ts
+++ b/packages/keymaster/src/account.ts
@@ -471,7 +471,11 @@ export class Network {
       (acc, v) => acc.add(v),
       ethers.BigNumber.from("0")
     );
-    this.bank._threshold = threshold;
+    
+    // Temporary hardcode value, so that we don't get much noise when currently we don't want to put 26 eth into the bank
+    // TODO: fix strategy
+    // this.bank._threshold = threshold;
+    this.bank._threshold = eth(4);
   }
 
   async checkAllBalances() {

--- a/packages/keymaster/src/config.ts
+++ b/packages/keymaster/src/config.ts
@@ -9,12 +9,26 @@ export function justAddress(a: AddressWithThreshold): string {
   return typeof a === "string" ? a : a.address;
 }
 
+export enum AgentRole {
+  Updater = "updater",
+  Relayer = "relayer",
+  Processor = "processor",
+  Watcher = "watcher",
+  Kathy = "kathy",
+}
+
 export interface AgentAddresses {
   kathy?: AddressWithThreshold;
   watchers: AddressWithThreshold[];
   updater: AddressWithThreshold;
   relayer: AddressWithThreshold;
   processor: AddressWithThreshold;
+}
+
+export interface Ignores {
+  all?: AgentRole[];
+  local?: AgentRole[];
+  remote?: AgentRole[];
 }
 
 export interface INetwork {
@@ -25,8 +39,24 @@ export interface INetwork {
   threshold: ethers.BigNumber;
   watcherThreshold: ethers.BigNumber;
   agents: AgentAddresses;
+  ignore?: Ignores;
 }
 
 export interface KeymasterConfig {
   networks: INetwork[];
+}
+
+export function allowAgent(
+  n: INetwork,
+  where: "local" | "remote",
+  role: AgentRole
+) {
+  if (!n.ignore) return true;
+  if (n.ignore.all?.includes(role)) return false;
+
+  if (where === "local") {
+    return !n.ignore.local?.includes(role);
+  } else {
+    return !n.ignore.remote?.includes(role);
+  }
 }

--- a/packages/keymaster/src/kms/index.ts
+++ b/packages/keymaster/src/kms/index.ts
@@ -57,6 +57,9 @@ export class AwsKmsSigner extends ethers.Signer {
     transaction: ethers.utils.Deferrable<ethers.providers.TransactionRequest>
   ): Promise<string> {
     const unsignedTx = await ethers.utils.resolveProperties(transaction);
+    if (unsignedTx.from != null) {
+      delete unsignedTx.from;
+    }
     const serializedTx = ethers.utils.serializeTransaction(
       <UnsignedTransaction>unsignedTx
     );

--- a/packages/keymaster/src/retry_provider/provider.ts
+++ b/packages/keymaster/src/retry_provider/provider.ts
@@ -1,6 +1,6 @@
 import { ethers } from "ethers";
 import { Context } from "../context";
-import { retry } from "../utils";
+import { sleep } from "../utils";
 
 export class MyJRPCProvider extends ethers.providers.StaticJsonRpcProvider {
   networkName: string;
@@ -20,18 +20,19 @@ export class MyJRPCProvider extends ethers.providers.StaticJsonRpcProvider {
 
   async perform(method: string, params: any): Promise<any> {
     this.ctx.logger.debug(`Performing method: ${method}`);
+    const timeout = 2000;
 
-    const [result, error] = await retry(
-      async () => {
+    let lastError;
+
+    for (let attempt = 0; attempt <= 5; attempt++) {
+      try {
         this.ctx.metrics.incRpcRequests(this.networkName, method);
         const start = new Date().valueOf();
         const result = await super.perform(method, params);
         const time = new Date().valueOf() - start;
         this.ctx.metrics.observeLatency(this.networkName, method, time);
         return result;
-      },
-      5,
-      (e) => {
+      } catch (e: any) {
         this.ctx.logger.error(
           {
             method,
@@ -47,14 +48,17 @@ export class MyJRPCProvider extends ethers.providers.StaticJsonRpcProvider {
           method,
           e.code || "NO_CODE"
         );
-      }
-    );
 
-    if (result) {
-      return result;
-    } else {
-      throw error;
+        if (e.code === "INSUFFICIENT_FUNDS") {
+          throw e;
+        } else {
+          lastError = e;
+          await sleep(timeout * 2 ** attempt);
+        }
+      }
     }
+
+    throw lastError;
   }
 
   async sendTransactionPlus(

--- a/packages/keymaster/src/retry_provider/provider.ts
+++ b/packages/keymaster/src/retry_provider/provider.ts
@@ -33,6 +33,7 @@ export class MyJRPCProvider extends ethers.providers.StaticJsonRpcProvider {
         this.ctx.metrics.observeLatency(this.networkName, method, time);
         return result;
       } catch (e: any) {
+        lastError = e;
         this.ctx.logger.error(
           {
             method,
@@ -49,10 +50,9 @@ export class MyJRPCProvider extends ethers.providers.StaticJsonRpcProvider {
           e.code || "NO_CODE"
         );
 
-        if (e.code === "INSUFFICIENT_FUNDS") {
+        if (e.code === "INSUFFICIENT_FUNDS" || e.code === "INVALID_ARGUMENT") {
           throw e;
         } else {
-          lastError = e;
           await sleep(timeout * 2 ** attempt);
         }
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1849,7 +1849,7 @@ __metadata:
     bunyan: ^1.8.15
     decimal.js: ^10.3.1
     dotenv: ^16.0.1
-    ethers: ^5.6.8
+    ethers: ^5.6.9
     express: ^4.18.1
     keccak: ^3.0.2
     prom-client: ^14.0.1
@@ -9365,7 +9365,7 @@ __metadata:
   dependencies:
     bn.js: ^4.11.8
     ethereumjs-util: ^6.0.0
-  checksum: ae074be0bb012857ab5d3ae644d1163b908a48dd724b7d2567cfde309dc72222d460438f2411936a70dc949dc604ce1ef7118f7273bd525815579143c907e336
+  checksum: 03127d09960e5f8a44167463faf25b2894db2f746376dbb8195b789ed11762f93db9c574eaa7c498c400063508e9dfc1c80de2edf5f0e1406b25c87d860ff2f1
   languageName: node
   linkType: hard
 
@@ -9621,7 +9621,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ethers@npm:^5.0.0, ethers@npm:^5.0.1, ethers@npm:^5.0.2, ethers@npm:^5.4.4, ethers@npm:^5.4.6, ethers@npm:^5.5.1, ethers@npm:^5.5.2, ethers@npm:^5.6.8":
+"ethers@npm:^5.0.0, ethers@npm:^5.0.1, ethers@npm:^5.0.2, ethers@npm:^5.4.4, ethers@npm:^5.4.6, ethers@npm:^5.5.1, ethers@npm:^5.5.2, ethers@npm:^5.6.8, ethers@npm:^5.6.9":
   version: 5.6.9
   resolution: "ethers@npm:5.6.9"
   dependencies:


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below. Bug fixes and new features should include tests.

New contributors should read the contributors guide:
https://github.com/nomad-xyz/monorepo/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building
the documentation.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

I have added this fields to config. If there is an ignore field there are 3 sub-fields all , local , remote . If an agent role name (lets say watcher) happen to appear in:
all then remote and local watchers not working anymore
local  then local watchers not working
remote  guess what happens...
Noteworthy, kathy  or updater  can appear only in the local network. I don't care right now.

also, hardcoded bank threshold to 4 eth, as we don't want to have 20+ eth in the bank


<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Updated Documentation
- [x] Updated CHANGELOG.md for the appropriate package
