### PR TITLE
Fix version endpoint on indexer api

### DIFF
--- a/.github/workflows/indexer-docker.yml
+++ b/.github/workflows/indexer-docker.yml
@@ -3,14 +3,14 @@
 # https://github.com/docker/login-action#google-container-registry-gcr
 # https://github.com/docker/build-push-action
 name: Push Indexer Image to GCR GitHub Action
-on: 
+on:
   push:
     paths:
-      - 'packages/indexer/**'
+      - "packages/indexer/**"
     branches:
-      - '**'
+      - "**"
     tags:
-      - '**'
+      - "**"
 
 jobs:
   build-docker:
@@ -49,3 +49,5 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            GIT_COMMIT=${{ github.sha }}

--- a/packages/indexer/CHANGELOG.md
+++ b/packages/indexer/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Unreleased
 
+- fix: pass github.sha as build arg to github actions docker/build-push-action step
 - chore: update package scripts to start / stop services from monorepo root
 - chore: refactor api service
 - chore: standardize script commands

--- a/packages/indexer/package.json
+++ b/packages/indexer/package.json
@@ -8,8 +8,8 @@
   "scripts": {
     "docker:build": "docker-compose build --build-arg GIT_COMMIT=$(git rev-parse --short HEAD)",
     "docker:down": "docker-compose down",
-    "docker:release": "docker buildx build --build-arg GIT_COMMIT=$(git rev-parse --short HEAD) --platform linux/amd64,linux/arm64 --push -t gcr.io/nomad-xyz/nomad-indexer:sha-$(git rev-parse --short HEAD) .",
-    "docker:stop": "docker-comopose stop",
+    "docker:release": "docker buildx build --build-arg GIT_COMMIT=$(git rev-parse --short HEAD) --platform=linux/amd64,linux/arm64 --push -t=gcr.io/nomad-xyz/nomad-indexer:sha-$(git rev-parse --short HEAD) .",
+    "docker:stop": "docker-compose stop",
     "docker:up": "docker-compose up",
     "lint": "eslint --fix ./src",
     "prisma:generate": "prisma generate",


### PR DESCRIPTION
## Motivation

/version endpoint wasn't returning a commit sha which is super helpful for debugging and knowing exactly which commit is deployed.

## Solution

Pass commit sha as build arg to github actions docker/build-push-action step

## PR Checklist

- [ ] Added Tests
- [ ] Updated Documentation
- [x] Updated CHANGELOG.md for the appropriate package
