### PR TITLE
fix: enroll BridgeRouter and GovernanceRouter if re-deployed

### DIFF
--- a/packages/deploy/src/bridge/BridgeContracts.ts
+++ b/packages/deploy/src/bridge/BridgeContracts.ts
@@ -360,7 +360,7 @@ export default class BridgeContracts extends AbstractBridgeDeploy<config.EvmBrid
     const enrolledRemote = await this.bridgeRouterContract.remotes(
       remoteConfig.domain,
     );
-    if (!utils.equalIds(enrolledRemote, remoteBridge.bridgeRouterContract.address)) return;
+    if (utils.equalIds(enrolledRemote, remoteBridge.bridgeRouterContract.address)) return;
     log(`enroll BridgeRouter for ${remoteName} on ${local}`);
 
     // Check that this key has permissions to set this

--- a/packages/deploy/src/bridge/BridgeContracts.ts
+++ b/packages/deploy/src/bridge/BridgeContracts.ts
@@ -360,7 +360,7 @@ export default class BridgeContracts extends AbstractBridgeDeploy<config.EvmBrid
     const enrolledRemote = await this.bridgeRouterContract.remotes(
       remoteConfig.domain,
     );
-    if (!utils.equalIds(enrolledRemote, ethers.constants.AddressZero)) return;
+    if (!utils.equalIds(enrolledRemote, remoteBridge.bridgeRouterContract.address)) return;
     log(`enroll BridgeRouter for ${remoteName} on ${local}`);
 
     // Check that this key has permissions to set this

--- a/packages/deploy/src/core/CoreContracts.ts
+++ b/packages/deploy/src/core/CoreContracts.ts
@@ -603,7 +603,7 @@ export default class EvmCoreDeploy extends AbstractCoreDeploy<config.EvmCoreCont
     const enrolledRemote = await this.governanceRouter.routers(
       remoteConfig.domain,
     );
-    if (!utils.equalIds(enrolledRemote, ethers.constants.AddressZero)) return;
+    if (!utils.equalIds(enrolledRemote, remoteCore.governanceRouter.address)) return;
     log(`enroll GovernanceRouter for ${remote} on ${local}`);
 
     // Check that this key has permissions to set this

--- a/packages/deploy/src/core/CoreContracts.ts
+++ b/packages/deploy/src/core/CoreContracts.ts
@@ -603,7 +603,7 @@ export default class EvmCoreDeploy extends AbstractCoreDeploy<config.EvmCoreCont
     const enrolledRemote = await this.governanceRouter.routers(
       remoteConfig.domain,
     );
-    if (!utils.equalIds(enrolledRemote, remoteCore.governanceRouter.address)) return;
+    if (utils.equalIds(enrolledRemote, remoteCore.governanceRouter.address)) return;
     log(`enroll GovernanceRouter for ${remote} on ${local}`);
 
     // Check that this key has permissions to set this


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below. Bug fixes and new features should include tests.

New contributors should read the contributors guide:
https://github.com/nomad-xyz/monorepo/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building
the documentation.
-->

## Motivation
If contracts were previously enrolled for a remote domain, the deploy script does not execute governance transactions to change the router.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Fix the condition which skips enrolling routers to ensure that the correct router is enrolled (rather than no router enrolled).

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Updated Documentation
- [ ] Updated CHANGELOG.md for the appropriate package
