### PR TITLE
Make keymaster run networks in parallel (concurrently)

### DIFF
--- a/packages/keymaster/CHANGELOG.md
+++ b/packages/keymaster/CHANGELOG.md
@@ -6,3 +6,4 @@
 - Can use either KMS or private key signer to fund agents
 - Ethers.js provider which has retry logic and observability through prometheus
 - Can ignore agents from remote networks, like processors, and can ignore local ones like updater or kathy
+- Run all nets concurrently

--- a/packages/keymaster/src/account.ts
+++ b/packages/keymaster/src/account.ts
@@ -18,10 +18,10 @@ dotenv.config();
 const prettyPrint = process.env.PRETTY_PRINT === "true";
 
 const hardcodedGasLimits: Record<string, ethers.BigNumberish> = {
-  "bsctestnet": 30000,
-  "arbitrumrinkeby": 600000,
-  "optimismkovan": 30000,
-  "optimismgoerli": 30000,
+  bsctestnet: 30000,
+  arbitrumrinkeby: 600000,
+  optimismkovan: 30000,
+  optimismgoerli: 30000,
 };
 
 export abstract class Accountable {
@@ -360,7 +360,7 @@ export class Bank extends Accountable {
       `Paying from signer of a bank`
     );
 
-    const gasLimit = hardcodedGasLimits[this.home.name]
+    const gasLimit = hardcodedGasLimits[this.home.name];
     const sent = await this.signer.sendTransaction({ to, value, gasLimit });
 
     let receipt;

--- a/packages/keymaster/src/index.ts
+++ b/packages/keymaster/src/index.ts
@@ -17,10 +17,7 @@ async function run(
   const km = await new Keymaster(config).init();
   km.ctx.metrics.startServer(port);
 
-  while (true) {
-    await km.checkAndPayEnabledNetworks(NETWORK_ENABLED, dryrun);
-    await sleep(period * 1000);
-  }
+  await km.checkAndPayEnabledNetworks(NETWORK_ENABLED, period, dryrun);
 }
 
 (async () => {

--- a/packages/keymaster/src/keymaster.ts
+++ b/packages/keymaster/src/keymaster.ts
@@ -95,6 +95,11 @@ export class Keymaster {
     dryrun = false
   ): Promise<void> {
     const promises = Array.from(this.networks.values()).map(async (net) => {
+      // Here we are creating a promise for every network,
+      // which is just try-catch loop, that isn't expected to stop.
+      // That's why we don't want to return anything that would be processed.
+      // If there would be an unhandled promise rejection it would kill the app anyways,
+      // so we don't attempt to handle it higher the stack.
       while (true) {
         try {
           if (networks.length === 0 || networks.includes(net.name)) {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below. Bug fixes and new features should include tests.

New contributors should read the contributors guide:
https://github.com/nomad-xyz/monorepo/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building
the documentation.
-->

## Motivation
Right now keymaster runs nets one by one sequentially, to make it easier to debug. But, we see that it is quite stable, though if there are many networks it takes lots of time to till one net at the end of the queue will get checked and paid.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Now we want all nets to have their own loop.

It spins up one "task" per network and the task spins until it breaks in a try-catch loop until an unhandled promise rejection happens, which is impossible to catch anyways. 
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Updated Documentation
- [x] Updated CHANGELOG.md for the appropriate package
