### PR TITLE
feat: output config & verification each time new contracts are deployed

### DIFF
--- a/packages/deploy/scripts/deploy.ts
+++ b/packages/deploy/scripts/deploy.ts
@@ -2,7 +2,6 @@ import { DeployContext } from '../src/DeployContext';
 import * as config from '@nomad-xyz/configuration';
 import * as ethers from 'ethers';
 import { NonceManager } from '@ethersproject/experimental';
-import fs from 'fs';
 import * as dotenv from 'dotenv';
 import { getConfig, getOverrides } from './utils';
 dotenv.config();
@@ -10,9 +9,12 @@ dotenv.config();
 run();
 
 async function run() {
+  // define the directory for deploy outputs
+  const outputDir = './output';
+
   // instantiate deploy context
   const DEPLOY_CONFIG: config.NomadConfig = getConfig();
-  const deployContext = new DeployContext(DEPLOY_CONFIG);
+  const deployContext = new DeployContext(DEPLOY_CONFIG, outputDir);
 
   // get deploy signer and overrides
   const DEPLOYER_PRIVATE_KEY = process.env.DEPLOYER_PRIVATE_KEY;
@@ -28,56 +30,17 @@ async function run() {
     deployContext.registerSigner(network, signer);
     deployContext.overrides.set(network, OVERRIDES[network]);
   }
-  const outputDir = './output';
   try {
     // run the deploy script
     await deployContext.deployAndRelinquish();
 
-    // output the updated config & verification
-    outputConfigAndVerification(outputDir, deployContext);
-
-    // output the governance transactions when the deploy succeeds
-    // (if the deploy script throws, the callBatch will be
-    // re-generated idempotently when the script ultimately succeeds)
-    await outputCallBatch(outputDir, deployContext);
-
     console.log(`DONE!`);
   } catch (e) {
     // if the deploy script fails,
-    // output the updated config & verification
+    // ensure the updated config & verification are outputted
     // then re-run the script to pick up where it left off
-    outputConfigAndVerification(outputDir, deployContext);
+    deployContext.output();
     
     throw e;
-  }
-}
-
-function outputConfigAndVerification(outputDir: string, deployContext: DeployContext) {
-  // output the config
-  fs.mkdirSync(outputDir, {recursive: true});
-  fs.writeFileSync(
-      `${outputDir}/config.json`,
-      JSON.stringify(deployContext.data, null, 2),
-  );
-  // if new contracts were deployed,
-  const verification = Object.fromEntries(deployContext.verification);
-  if (Object.keys(verification).length > 0) {
-    // output the verification inputs
-    fs.writeFileSync(
-        `${outputDir}/verification-${Date.now()}.json`,
-        JSON.stringify(verification, null, 2),
-    );
-  }
-}
-
-async function outputCallBatch(outputDir: string, deployContext: DeployContext) {
-  const governanceBatch = deployContext.callBatch;
-  if (!governanceBatch.isEmpty()) {
-    // build & write governance batch
-    await governanceBatch.build();
-    fs.writeFileSync(
-        `${outputDir}/governanceTransactions.json`,
-        JSON.stringify(governanceBatch, null, 2),
-    );
   }
 }

--- a/packages/deploy/src/DeployContext.ts
+++ b/packages/deploy/src/DeployContext.ts
@@ -134,10 +134,12 @@ export class DeployContext extends MultiProvider<config.Domain> {
 
   protected addCore(name: string, core: config.EvmCoreContracts): void {
     this._data = config.addCore(this.data, name, core);
+    this.output();
   }
 
   protected addBridge(name: string, bridge: config.EvmBridgeContracts): void {
     this._data = config.addBridge(this.data, name, bridge);
+    this.output();
   }
 
   pushVerification(
@@ -230,11 +232,7 @@ export class DeployContext extends MultiProvider<config.Domain> {
   async ensureCores(): Promise<void> {
     const networksToDeploy = this.networks.filter((net) => !this.cores[net]);
     await Promise.all(
-      networksToDeploy.map(async (net) => {
-          await this.deployCore(this.mustGetDomainConfig(net));
-          this.output();
-        },
-      ),
+      networksToDeploy.map(async (net) => this.deployCore(this.mustGetDomainConfig(net))),
     );
   }
 
@@ -276,10 +274,7 @@ export class DeployContext extends MultiProvider<config.Domain> {
   /// Deploys all configured bridges.
   async ensureBridges(): Promise<void> {
     const toDeploy = this.networks.filter((net) => !this.bridges[net]);
-    await Promise.all(toDeploy.map(async (net) => {
-      await this.deployBridge(net);
-      this.output();
-    }));
+    await Promise.all(toDeploy.map(async (net) => this.deployBridge(net)));
   }
 
   async ensureBridgeConnections(): Promise<void> {

--- a/packages/deploy/src/DeployContext.ts
+++ b/packages/deploy/src/DeployContext.ts
@@ -23,6 +23,7 @@ export class DeployContext extends MultiProvider<config.Domain> {
   protected _verification: Map<string, Array<Verification>>;
   protected _callBatch: CallBatch;
   protected _outputDir: string;
+  protected _instantiatedAt: number;
 
   constructor(data: config.NomadConfig, outputDir: string) {
     super();
@@ -31,6 +32,7 @@ export class DeployContext extends MultiProvider<config.Domain> {
     this.overrides = new Map();
     this._verification = new Map();
     this._outputDir = outputDir;
+    this._instantiatedAt = Date.now();
 
     for (const network of this.data.networks) {
       this.registerDomain(this.data.protocol.networks[network]);
@@ -73,6 +75,10 @@ export class DeployContext extends MultiProvider<config.Domain> {
 
   get outputDir(): Readonly<string> {
     return this._outputDir;
+  }
+
+  get instantiatedAt(): Readonly<number> {
+    return this._instantiatedAt;
   }
 
   get verification(): Readonly<Map<string, ReadonlyArray<Verification>>> {
@@ -175,8 +181,10 @@ export class DeployContext extends MultiProvider<config.Domain> {
     const verification = Object.fromEntries(this.verification);
     if (Object.keys(verification).length > 0) {
       // output the verification inputs
+      // Note: append the timestamp so that
+      // verification outputs for different runs are disambiguated
       fs.writeFileSync(
-          `${this.outputDir}/verification-${Date.now()}.json`,
+          `${this.outputDir}/verification-${this.instantiatedAt}.json`,
           JSON.stringify(verification, null, 2),
       );
     }

--- a/packages/deploy/src/DeployContext.ts
+++ b/packages/deploy/src/DeployContext.ts
@@ -7,7 +7,7 @@ import ethers from 'ethers';
 
 import BridgeContracts from './bridge/BridgeContracts';
 import CoreContracts from './core/CoreContracts';
-import fs from "fs";
+import fs from 'fs';
 
 export interface Verification {
   name: string;
@@ -172,10 +172,10 @@ export class DeployContext extends MultiProvider<config.Domain> {
 
   output(): void {
     // output the config
-    fs.mkdirSync(this.outputDir, {recursive: true});
+    fs.mkdirSync(this.outputDir, { recursive: true });
     fs.writeFileSync(
-        `${this.outputDir}/config.json`,
-        JSON.stringify(this.data, null, 2),
+      `${this.outputDir}/config.json`,
+      JSON.stringify(this.data, null, 2),
     );
     // if new contracts were deployed,
     const verification = Object.fromEntries(this.verification);
@@ -184,8 +184,8 @@ export class DeployContext extends MultiProvider<config.Domain> {
       // Note: append the timestamp so that
       // verification outputs for different runs are disambiguated
       fs.writeFileSync(
-          `${this.outputDir}/verification-${this.instantiatedAt}.json`,
-          JSON.stringify(verification, null, 2),
+        `${this.outputDir}/verification-${this.instantiatedAt}.json`,
+        JSON.stringify(verification, null, 2),
       );
     }
   }
@@ -196,8 +196,8 @@ export class DeployContext extends MultiProvider<config.Domain> {
       // build & write governance batch
       await governanceBatch.build();
       fs.writeFileSync(
-          `${this.outputDir}/governanceTransactions.json`,
-          JSON.stringify(governanceBatch, null, 2),
+        `${this.outputDir}/governanceTransactions.json`,
+        JSON.stringify(governanceBatch, null, 2),
       );
     }
   }
@@ -240,7 +240,9 @@ export class DeployContext extends MultiProvider<config.Domain> {
   async ensureCores(): Promise<void> {
     const networksToDeploy = this.networks.filter((net) => !this.cores[net]);
     await Promise.all(
-      networksToDeploy.map((net) => this.deployCore(this.mustGetDomainConfig(net))),
+      networksToDeploy.map((net) =>
+        this.deployCore(this.mustGetDomainConfig(net)),
+      ),
     );
   }
 

--- a/packages/deploy/src/DeployContext.ts
+++ b/packages/deploy/src/DeployContext.ts
@@ -240,7 +240,7 @@ export class DeployContext extends MultiProvider<config.Domain> {
   async ensureCores(): Promise<void> {
     const networksToDeploy = this.networks.filter((net) => !this.cores[net]);
     await Promise.all(
-      networksToDeploy.map(async (net) => this.deployCore(this.mustGetDomainConfig(net))),
+      networksToDeploy.map((net) => this.deployCore(this.mustGetDomainConfig(net))),
     );
   }
 
@@ -282,7 +282,7 @@ export class DeployContext extends MultiProvider<config.Domain> {
   /// Deploys all configured bridges.
   async ensureBridges(): Promise<void> {
     const toDeploy = this.networks.filter((net) => !this.bridges[net]);
-    await Promise.all(toDeploy.map(async (net) => this.deployBridge(net)));
+    await Promise.all(toDeploy.map((net) => this.deployBridge(net)));
   }
 
   async ensureBridgeConnections(): Promise<void> {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below. Bug fixes and new features should include tests.

New contributors should read the contributors guide:
https://github.com/nomad-xyz/monorepo/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building
the documentation.
-->

## Motivation
The deploy script would often fail without throwing an error by hanging indefinitely after submitting a transaction. In this case, if a developer killed the process to re-start the deploy script, the partial config & verification outputs would not be written to a file, meaning that the deploy process would have to restart from scratch and throw away the contracts deployed during the previous run. 

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Output the config & verification to a file each time it's possible after contracts are deployed, so a developer can kill the process any time if a transaction is hanging

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Updated Documentation
- [ ] Updated CHANGELOG.md for the appropriate package
