### PR TITLE
feat: add token sender to TransferToHook message

### DIFF
--- a/packages/contracts-bridge/contracts/BridgeMessage.sol
+++ b/packages/contracts-bridge/contracts/BridgeMessage.sol
@@ -411,7 +411,7 @@ library BridgeMessage {
     /**
      * @notice Retrieves the extra data from a TransferWithHook
      * @param _transferAction The message
-     * @return The extra data as a bytes29
+     * @return A TypedMemview of extraData
      */
     function extraData(bytes29 _transferAction)
         internal

--- a/packages/contracts-bridge/contracts/BridgeMessage.sol
+++ b/packages/contracts-bridge/contracts/BridgeMessage.sol
@@ -50,7 +50,8 @@ library BridgeMessage {
 
     uint256 private constant TOKEN_ID_LEN = 36; // 4 bytes domain + 32 bytes id
     uint256 private constant IDENTIFIER_LEN = 1;
-    uint256 private constant MIN_TRANSFER_LEN = 97; // 1 byte identifier + 32 bytes recipient or externalId + 32 bytes amount + 32 bytes detailsHash
+    uint256 private constant TRANSFER_LEN = 97; // 1 byte identifier + 32 bytes recipient + 32 bytes amount + 32 bytes detailsHash
+    uint256 private constant MIN_TRANSFER_HOOK_LEN = 129; // 1 byte identifier + 32 bytes hook address + 32 bytes amount + 32 bytes detailsHash + 32 bytes sender + X bytes extraData
 
     // ============ Modifiers ============
 
@@ -82,7 +83,9 @@ library BridgeMessage {
      */
     function isValidMessageLength(bytes29 _view) internal pure returns (bool) {
         uint256 _len = _view.len();
-        return _len >= TOKEN_ID_LEN + MIN_TRANSFER_LEN;
+        return
+            _len == TOKEN_ID_LEN + TRANSFER_LEN ||
+            _len >= TOKEN_ID_LEN + MIN_TRANSFER_HOOK_LEN;
     }
 
     /**
@@ -173,6 +176,7 @@ library BridgeMessage {
         bytes32 _hook,
         uint256 _amnt,
         bytes32 _detailsHash,
+        bytes32 _sender,
         bytes memory _extraData
     ) internal pure returns (bytes29) {
         return
@@ -182,6 +186,7 @@ library BridgeMessage {
                     _hook,
                     _amnt,
                     _detailsHash,
+                    _sender,
                     _extraData
                 )
                 .ref(uint40(Types.TransferToHook));
@@ -377,7 +382,7 @@ library BridgeMessage {
     /**
      * @notice Retrieves the hook contract EVM address from a TransferWithHook
      * @param _transferAction The message
-     * @return The hook contract address as bytes32
+     * @return The hook contract address
      */
     function evmHook(bytes29 _transferAction)
         internal
@@ -388,6 +393,26 @@ library BridgeMessage {
         return _transferAction.indexAddress(13);
     }
 
+    /**
+     * @notice Retrieves the sender from a TransferWithHook
+     * @param _transferAction The message
+     * @return The sender as bytes32
+     */
+    function sender(bytes29 _transferAction)
+        internal
+        pure
+        typeAssert(_transferAction, Types.TransferToHook)
+        returns (bytes32)
+    {
+        // before = 1 byte identifier + 32 bytes hook address + 32 bytes amount + 32 bytes detailsHash = 97
+        return _transferAction.index(97, 32);
+    }
+
+    /**
+     * @notice Retrieves the extra data from a TransferWithHook
+     * @param _transferAction The message
+     * @return The extra data as a bytes29
+     */
     function extraData(bytes29 _transferAction)
         internal
         pure
@@ -397,8 +422,8 @@ library BridgeMessage {
         // anything past the end is the extradata
         return
             _transferAction.slice(
-                MIN_TRANSFER_LEN,
-                _transferAction.len() - MIN_TRANSFER_LEN,
+                MIN_TRANSFER_HOOK_LEN,
+                _transferAction.len() - MIN_TRANSFER_HOOK_LEN,
                 uint40(Types.ExtraData)
             );
     }

--- a/packages/contracts-bridge/contracts/BridgeRouter.sol
+++ b/packages/contracts-bridge/contracts/BridgeRouter.sol
@@ -10,6 +10,7 @@ import {IBridgeHook} from "./interfaces/IBridgeHook.sol";
 import {XAppConnectionClient} from "@nomad-xyz/contracts-router/contracts/XAppConnectionClient.sol";
 import {Router} from "@nomad-xyz/contracts-router/contracts/Router.sol";
 import {Home} from "@nomad-xyz/contracts-core/contracts/Home.sol";
+import {TypeCasts} from "@nomad-xyz/contracts-core/contracts/libs/TypeCasts.sol";
 import {Version0} from "@nomad-xyz/contracts-core/contracts/Version0.sol";
 import {TypedMemView} from "@summa-tx/memview-sol/contracts/TypedMemView.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
@@ -190,6 +191,7 @@ contract BridgeRouter is Version0, Router {
             _remoteHook,
             _amount,
             _detailsHash,
+            TypeCasts.addressToBytes32(msg.sender),
             _extraData
         );
         // send message to destination chain bridge router
@@ -364,6 +366,7 @@ contract BridgeRouter is Version0, Router {
         bytes memory _call = abi.encodeWithSelector(
             IBridgeHook.onReceive.selector,
             _origin,
+            _action.sender(),
             _tokenId.domain(),
             _tokenId.id(),
             _token,

--- a/packages/contracts-bridge/contracts/interfaces/IBridgeHook.sol
+++ b/packages/contracts-bridge/contracts/interfaces/IBridgeHook.sol
@@ -16,6 +16,7 @@ interface IBridgeHook {
      * in place for these situations.
      *
      * @param _origin The domain of the chain from which the transfer originated
+     * @param _sender The identifier of the caller which sent the tokens over the bridge
      * @param _tokenDomain The canonical deployment domain of the token
      * @param _tokenAddress The identifier for the token on its canonical domain
      * @param _localToken The local address of the token (its canonical
@@ -26,6 +27,7 @@ interface IBridgeHook {
      */
     function onReceive(
         uint32 _origin,
+        bytes32 _sender,
         uint32 _tokenDomain,
         bytes32 _tokenAddress,
         address _localToken,

--- a/packages/contracts-bridge/contracts/test/BridgeMessage.t.sol
+++ b/packages/contracts-bridge/contracts/test/BridgeMessage.t.sol
@@ -224,7 +224,8 @@ contract BridgeMessageTest is Test {
                 BridgeMessage.Types.TransferToHook,
                 tokenReceiver,
                 tokenAmount,
-                tokenDetailsHash
+                tokenDetailsHash,
+                tokenSender
             )
             .ref(uint40(BridgeMessage.Types.TransferToHook));
         assert(
@@ -270,7 +271,8 @@ contract BridgeMessageTest is Test {
                 BridgeMessage.Types.TransferToHook,
                 tokenReceiver,
                 tokenAmount,
-                tokenDetailsHash
+                tokenDetailsHash,
+                tokenSender
             )
             .ref(uint40(BridgeMessage.Types.TransferToHook));
         assert(BridgeMessage.isTransferToHook(action));
@@ -310,6 +312,7 @@ contract BridgeMessageTest is Test {
                 tokenReceiver,
                 tokenAmount,
                 tokenDetailsHash,
+                tokenSender,
                 extraData
             )
             .ref(uint40(BridgeMessage.Types.TransferToHook));
@@ -317,6 +320,7 @@ contract BridgeMessageTest is Test {
             tokenReceiver,
             tokenAmount,
             tokenDetailsHash,
+            tokenSender,
             extraData
         );
         assertEq(transfer.keccak(), manualTransfer.keccak());
@@ -448,7 +452,8 @@ contract BridgeMessageTest is Test {
                 BridgeMessage.Types.TransferToHook,
                 tokenReceiver,
                 tokenAmount,
-                tokenDetailsHash
+                tokenDetailsHash,
+                tokenSender
             )
             .ref(0);
         assertEq(
@@ -538,6 +543,7 @@ contract BridgeMessageTest is Test {
                 tokenReceiver,
                 tokenAmount,
                 tokenDetailsHash,
+                tokenSender,
                 new bytes(100)
             )
             .ref(uint40(BridgeMessage.Types.TransferToHook));
@@ -545,6 +551,20 @@ contract BridgeMessageTest is Test {
             BridgeMessage.evmHook(action),
             TypeCasts.bytes32ToAddress(tokenReceiver)
         );
+    }
+
+    function test_senderReturnsCorrectBytes32() public {
+        bytes29 action = abi
+            .encodePacked(
+                BridgeMessage.Types.TransferToHook,
+                tokenReceiver,
+                tokenAmount,
+                tokenDetailsHash,
+                tokenSender,
+                new bytes(100)
+            )
+            .ref(uint40(BridgeMessage.Types.TransferToHook));
+        assertEq(BridgeMessage.sender(action), tokenSender);
     }
 
     function test_extraDataReturnsCorrectData() public {
@@ -555,6 +575,7 @@ contract BridgeMessageTest is Test {
                 tokenReceiver,
                 tokenAmount,
                 tokenDetailsHash,
+                tokenSender,
                 manExtraData
             )
             .ref(uint40(BridgeMessage.Types.TransferToHook));
@@ -570,7 +591,8 @@ contract BridgeMessageTest is Test {
                 BridgeMessage.Types.TransferToHook,
                 tokenReceiver,
                 tokenAmount,
-                tokenDetailsHash
+                tokenDetailsHash,
+                tokenSender
             )
             .ref(uint40(BridgeMessage.Types.TransferToHook));
         assert(action.isType(BridgeMessage.Types.TransferToHook));


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below. Bug fixes and new features should include tests.

New contributors should read the contributors guide:
https://github.com/nomad-xyz/monorepo/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building
the documentation.
-->

## Motivation
Routers that build on top of Nomad Home need to authenticate the sender of the message is a valid Router on the other chain. Similarly, Routers that build on top of Nomad BridgeRouter need to do the same.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Add the sender of the tokens + message on the origin chain to the TransferToHook message format.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [x] Added Tests
- [ ] Updated Documentation
- [x] Updated CHANGELOG.md for the appropriate package
