### PR TITLE
fix: force consistent casing in file names in nomad-cli tsconfig

### DIFF
--- a/packages/nomad-cli/package.json
+++ b/packages/nomad-cli/package.json
@@ -68,11 +68,6 @@
       "@oclif/plugin-help",
       "@oclif/plugin-plugins"
     ],
-    "topicSeparator": " ",
-    "topics": {
-      "hello": {
-        "description": "Say hello to the world and others"
-      }
-    }
+    "topicSeparator": " "
   }
 }

--- a/packages/nomad-cli/tsconfig.json
+++ b/packages/nomad-cli/tsconfig.json
@@ -5,7 +5,8 @@
     "rootDir": "src",
     // See issue for why we need these compiler options: https://github.com/oclif/core/issues/421#issuecomment-1133125992
     "module": "ES2020",
-    "moduleResolution": "node16"
+    "moduleResolution": "node16",
+    "forceConsistentCasingInFileNames": false,
   },
   "exclude": [
     "node_modules",


### PR DESCRIPTION
## Motivation

Error when trying to build `nomad-cli` locally

```
../../node_modules/@types/web3/utils.d.ts:2:21 - error TS1149: File name '/users/imti/nomad/monorepo/node_modules/@types/underscore/index.d.ts' differs from already included file name '/Users/imti/Nomad/monorepo/node_modules/@types/underscore/index.d.ts' only in casing.
  The file is in the program because:
    Entry point for implicit type library 'underscore' with packageId '@types/underscore/index.d.ts@1.11.4'
    Imported via "underscore" from file '/Users/imti/Nomad/monorepo/node_modules/@types/web3/utils.d.ts' with packageId '@types/underscore/index.d.ts@1.11.4'

2 import * as us from "underscore";
                      ~~~~~~~~~~~~


Found 1 error.
```

## Solution

Set the compiler option `forceConsistentCasingInFileNames` to false in the tsconfig

## PR Checklist

- [ ] Added Tests
- [ ] Updated Documentation
- [ ] Updated CHANGELOG.md for the appropriate package
