### PR TITLE
Imti/separate coverage script for ts packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "snapshot:check": "yarn workspaces foreach -Apvt --include @nomad-xyz/contracts-core --include @nomad-xyz/contracts-bridge run snapshot:check",
     "storage-inspect:check": "yarn workspaces foreach -Apvi --include @nomad-xyz/contracts-core --include @nomad-xyz/contracts-bridge --include @nomad-xyz/contracts-router run storage-inspect:check",
     "storage-inspect:generate": "yarn workspaces foreach -Apvi --include @nomad-xyz/contracts-core --include @nomad-xyz/contracts-bridge --include @nomad-xyz/contracts-router run storage-inspect:generate",
-    "coverage": "yarn workspaces foreach -Apvi --include @nomad-xyz/contracts-core --include @nomad-xyz/contracts-bridge --include @nomad-xyz/contracts-router run coverage",
+    "coverage": "yarn workspaces foreach -Apvi run coverage",
     "test:integration": "yarn local-environment test:integration",
     "test:unit": "yarn workspaces foreach -Apvt --exclude @nomad-xyz/deploy run test:unit"
   },

--- a/packages/chain-ops/.gitignore
+++ b/packages/chain-ops/.gitignore
@@ -2,4 +2,4 @@
 dist/
 tsconfig.tsbuildinfo
 .nyc_output/
-coverage/
+.coverage/

--- a/packages/contracts-bridge/.gitignore
+++ b/packages/contracts-bridge/.gitignore
@@ -1,7 +1,7 @@
 node_modules/
 cache/
 artifacts/
-coverage/
+.coverage/
 coverage.json
 .env
 src.ts/

--- a/packages/contracts-core/.gitignore
+++ b/packages/contracts-core/.gitignore
@@ -1,7 +1,7 @@
 /node_modules
 cache/
 artifacts/
-coverage/
+.coverage/
 coverage.json
 .env
 src.ts/

--- a/packages/contracts-router/.gitignore
+++ b/packages/contracts-router/.gitignore
@@ -1,7 +1,7 @@
 node_modules/
 cache/
 artifacts/
-coverage/
+.coverage/
 coverage.json
 .env
 src.ts/

--- a/packages/deploy/.gitignore
+++ b/packages/deploy/.gitignore
@@ -5,4 +5,4 @@ dist/
 lib/
 output/
 config/config.json
-coverage/
+.coverage/

--- a/packages/deploy/jest.config.js
+++ b/packages/deploy/jest.config.js
@@ -1,8 +1,7 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
-  collectCoverage: true,
-  coverageDirectory: 'coverage',
+  coverageDirectory: '.coverage',
   verbose: true,
   globals: {
     'ts-jest': {

--- a/packages/deploy/package.json
+++ b/packages/deploy/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "build": "tsc --build",
     "check": "tsc --noEmit",
-    "coverage": "echo TODO: Fix tests",
+    "coverage": "jest --collectCoverage",
     "lint": "eslint --fix ./src",
     "prettier": "prettier --write ./src",
     "test:unit": "jest"

--- a/packages/local-environment/.gitignore
+++ b/packages/local-environment/.gitignore
@@ -1,5 +1,5 @@
 .env
 output/verification-*
 output/config.json
-coverage
+.coverage
 !output/.gitkeep

--- a/packages/local-environment/jest.config.ts
+++ b/packages/local-environment/jest.config.ts
@@ -19,28 +19,22 @@ export default {
   clearMocks: true,
 
   // Indicates whether the coverage information should be collected while executing the test
-  collectCoverage: true,
+  // collectCoverage: true,
 
   // An array of glob patterns indicating a set of files for which coverage information should be collected
   // collectCoverageFrom: undefined,
 
   // The directory where Jest should output its coverage files
-  coverageDirectory: "coverage",
+  coverageDirectory: ".coverage",
 
   // An array of regexp pattern strings used to skip coverage collection
-  coveragePathIgnorePatterns: [
-    "/node_modules/"
-  ],
+  coveragePathIgnorePatterns: ["/node_modules/"],
 
   // Indicates which provider should be used to instrument code for coverage
   // coverageProvider: "babel",
 
   // A list of reporter names that Jest uses when writing coverage reports
-  coverageReporters: [
-    "json",
-    "text",
-    "html",
-  ],
+  coverageReporters: ["json", "text", "html"],
 
   // An object that configures minimum threshold enforcement for coverage results
   // coverageThreshold: undefined,
@@ -136,7 +130,7 @@ export default {
   // setupFiles: [],
 
   //A list of paths to modules that run some code to configure or set up the testing framework before each test
-  setupFilesAfterEnv: ['./jest.setup.ts'],
+  setupFilesAfterEnv: ["./jest.setup.ts"],
 
   // The number of seconds after which a test is considered as slow and reported as such in the results.
   // slowTestThreshold: 5,
@@ -193,5 +187,4 @@ export default {
 
   // Whether to use watchman for file crawling
   // watchman: true,
-  
 };

--- a/packages/local-environment/package.json
+++ b/packages/local-environment/package.json
@@ -18,6 +18,7 @@
     "build": "tsc --build",
     "bootup": "./bootup.sh",
     "cleanup": "npm run hardhat_stop && npm run agents_stop && npm run agents_clean",
+    "coverage": "jest --collectCoverage",
     "hardhat_stop": "docker ps --filter name=_net -aq | xargs docker rm --force",
     "test:unit": "jest unit --detectOpenHandles --ci --forceExit",
     "test:integration": "jest int --detectOpenHandles --ci --forceExit",

--- a/packages/multi-provider/.gitignore
+++ b/packages/multi-provider/.gitignore
@@ -2,4 +2,4 @@
 dist/
 tsconfig.tsbuildinfo
 .nyc_output/
-coverage/
+.coverage/

--- a/packages/multi-provider/jest.config.js
+++ b/packages/multi-provider/jest.config.js
@@ -1,8 +1,7 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
-  collectCoverage: true,
-  coverageDirectory: 'coverage',
+  coverageDirectory: '.coverage',
   verbose: true,
   globals: {
     'ts-jest': {

--- a/packages/multi-provider/package.json
+++ b/packages/multi-provider/package.json
@@ -23,7 +23,7 @@
   "scripts": {
     "build": "tsc --build",
     "check": "tsc --noEmit",
-    "coverage": "echo TODO: Fix tests",
+    "coverage": "jest --collectCoverage",
     "lint": "eslint --fix ./src ./tests",
     "prettier": "prettier --write ./src ./tests",
     "test:unit": "jest"

--- a/packages/sdk-bridge/.gitignore
+++ b/packages/sdk-bridge/.gitignore
@@ -2,4 +2,4 @@
 dist/
 tsconfig.tsbuildinfo
 .nyc_output/
-coverage/
+.coverage/

--- a/packages/sdk-bridge/jest.config.js
+++ b/packages/sdk-bridge/jest.config.js
@@ -1,8 +1,7 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
-  collectCoverage: true,
-  coverageDirectory: 'coverage',
+  coverageDirectory: '.coverage',
   verbose: true,
   globals: {
     'ts-jest': {

--- a/packages/sdk-bridge/package.json
+++ b/packages/sdk-bridge/package.json
@@ -26,7 +26,7 @@
   "scripts": {
     "build": "tsc --build",
     "check": "tsc --noEmit",
-    "coverage": "echo TODO: Fix tests",
+    "coverage": "jest --collectCoverage",
     "lint": "eslint --fix ./src ./tests",
     "prettier": "prettier --write ./src ./tests",
     "test:unit": "jest"

--- a/packages/sdk-govern/.gitignore
+++ b/packages/sdk-govern/.gitignore
@@ -2,6 +2,6 @@
 dist/
 tsconfig.tsbuildinfo
 .nyc_output/
-coverage/
+.coverage/
 config/config.json
 config/callBatch.json

--- a/packages/sdk-govern/jest.config.js
+++ b/packages/sdk-govern/jest.config.js
@@ -1,8 +1,7 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
-  collectCoverage: true,
-  coverageDirectory: 'coverage',
+  coverageDirectory: '.coverage',
   verbose: true,
   globals: {
     'ts-jest': {

--- a/packages/sdk-govern/package.json
+++ b/packages/sdk-govern/package.json
@@ -26,7 +26,7 @@
   "scripts": {
     "build": "tsc --build",
     "check": "tsc --noEmit",
-    "coverage": "echo TODO: Fix tests",
+    "coverage": "jest --collectCoverage",
     "lint": "eslint --fix ./src ./tests",
     "prettier": "prettier --write ./src ./tests",
     "test:unit": "jest"

--- a/packages/sdk/.gitignore
+++ b/packages/sdk/.gitignore
@@ -2,4 +2,4 @@
 dist/
 tsconfig.tsbuildinfo
 .nyc_output/
-coverage/
+.coverage/

--- a/packages/sdk/jest.config.js
+++ b/packages/sdk/jest.config.js
@@ -1,8 +1,7 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
-  collectCoverage: true,
-  coverageDirectory: 'coverage',
+  coverageDirectory: '.coverage',
   verbose: true,
   globals: {
     'ts-jest': {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -25,7 +25,7 @@
   "scripts": {
     "build": "tsc --build",
     "check": "tsc --noEmit",
-    "coverage": "echo TODO: Fix tests",
+    "coverage": "jest --collectCoverage",
     "lint": "eslint --fix ./src ./tests",
     "prettier": "prettier --write ./src ./tests",
     "test:unit": "jest"


### PR DESCRIPTION
## Motivation

Wanted the test coverage script to include the typescript packages which collected test coverage by default. 

## Solution

Separate out the test coverage script and include the typescript packages as part of the monorepo workspace coverage script.

## PR Checklist

- [ ] Added Tests
- [ ] Updated Documentation
- [ ] Updated CHANGELOG.md for the appropriate package
