### PR TITLE
fix: filter scripts from hh compilation

### DIFF
--- a/packages/contracts-bridge/CHANGELOG.md
+++ b/packages/contracts-bridge/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Unreleased
 
+- (patch): filter scripts from hh compilation
+
 ### 2.0.0
 
 - (feat): accountant in typechain lib

--- a/packages/contracts-bridge/hardhat.config.ts
+++ b/packages/contracts-bridge/hardhat.config.ts
@@ -14,7 +14,10 @@ subtask(TASK_COMPILE_SOLIDITY_GET_SOURCE_PATHS).setAction(
   async (_, __, runSuper) => {
     const paths: string[] = await runSuper();
 
-    return paths.filter((p) => !p.endsWith(".t.sol") && !p.includes("test"));
+    return paths.filter(
+      (p) =>
+        !p.endsWith(".t.sol") && !p.includes("test") && !p.includes("scripts")
+    );
   }
 );
 

--- a/packages/contracts-core/CHANGELOG.md
+++ b/packages/contracts-core/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Unreleased
 
+- (patch): filter scripts from hh compilation
+
 ### 2.0.0
 
 - proveAndProcess now allows just-processing

--- a/packages/contracts-core/hardhat.config.ts
+++ b/packages/contracts-core/hardhat.config.ts
@@ -2,8 +2,8 @@ import "hardhat-gas-reporter";
 import "@nomiclabs/hardhat-etherscan";
 import "hardhat-packager";
 
-import {subtask} from "hardhat/config";
-import {TASK_COMPILE_SOLIDITY_GET_SOURCE_PATHS} from "hardhat/builtin-tasks/task-names";
+import { subtask } from "hardhat/config";
+import { TASK_COMPILE_SOLIDITY_GET_SOURCE_PATHS } from "hardhat/builtin-tasks/task-names";
 
 import * as dotenv from "dotenv";
 dotenv.config();
@@ -15,7 +15,10 @@ subtask(TASK_COMPILE_SOLIDITY_GET_SOURCE_PATHS).setAction(
   async (_, __, runSuper) => {
     const paths: string[] = await runSuper();
 
-    return paths.filter((p) => !p.endsWith(".t.sol") && !p.includes("test"));
+    return paths.filter(
+      (p) =>
+        !p.endsWith(".t.sol") && !p.includes("test") && !p.includes("scripts")
+    );
   }
 );
 

--- a/packages/contracts-router/CHANGELOG.md
+++ b/packages/contracts-router/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Unreleased
 
+- (patch): filter scripts from hh compilation
+
 ### 2.0.0
 
 - (patch) fix: prevent remote router from ever being 0 in `mustHaveRemote`

--- a/packages/contracts-router/hardhat.config.ts
+++ b/packages/contracts-router/hardhat.config.ts
@@ -14,7 +14,10 @@ subtask(TASK_COMPILE_SOLIDITY_GET_SOURCE_PATHS).setAction(
   async (_, __, runSuper) => {
     const paths: string[] = await runSuper();
 
-    return paths.filter((p) => !p.endsWith(".t.sol") && !p.includes("test"));
+    return paths.filter(
+      (p) =>
+        !p.endsWith(".t.sol") && !p.includes("test") && !p.includes("scripts")
+    );
   }
 );
 


### PR DESCRIPTION
## Motivation

prevent HH from barfing on scripts' use of forge

## Solution



## PR Checklist

- [ ] Added Tests
- [ ] Updated Documentation
- [x] Updated CHANGELOG.md for the appropriate package
