### PR TITLE
feature: prankable callbatch

### DIFF
--- a/packages/contracts-ops/CHANGELOG.md
+++ b/packages/contracts-ops/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Unreleased
 
+- feature: prankable callbatch
 - feature: JsonWriter
 - feature: replica enrollment
 - feature: callbatch contract

--- a/packages/contracts-ops/contracts/CallBatch.sol
+++ b/packages/contracts-ops/contracts/CallBatch.sol
@@ -100,6 +100,27 @@ abstract contract CallBatch is Script {
         buffer.writeSimpleObject("", "", kvs, true);
         buffer.flushTo(outputFile);
     }
+
+    function prank(address router) public {
+        // prank the router itself to avoid governor chain issues
+        vm.prank(router);
+        GovernanceRouter(router).executeGovernanceActions(
+            calls,
+            new uint32[](0),
+            new GovernanceMessage.Call[][](0)
+        );
+    }
+
+    function prankRecovery(address router) public {
+        // prank recovery (only works if recovery is active)
+        address recovery = GovernanceRouter(router).recoveryManager();
+        vm.prank(recovery);
+        GovernanceRouter(router).executeGovernanceActions(
+            calls,
+            new uint32[](0),
+            new GovernanceMessage.Call[][](0)
+        );
+    }
 }
 
 contract TestCallBatch is CallBatch {

--- a/packages/contracts-ops/contracts/CallBatch.sol
+++ b/packages/contracts-ops/contracts/CallBatch.sol
@@ -101,7 +101,7 @@ abstract contract CallBatch is Script {
         buffer.flushTo(outputFile);
     }
 
-    function prank(address router) public {
+    function prankExecuteBatch(address router) public {
         // prank the router itself to avoid governor chain issues
         vm.prank(router);
         GovernanceRouter(router).executeGovernanceActions(
@@ -111,7 +111,7 @@ abstract contract CallBatch is Script {
         );
     }
 
-    function prankRecovery(address router) public {
+    function prankRecoveryExecuteBatch(address router) public {
         // prank recovery (only works if recovery is active)
         address recovery = GovernanceRouter(router).recoveryManager();
         vm.prank(recovery);


### PR DESCRIPTION


## Motivation

Allow forktests to prank scripts

## Solution

Add prank() and prankRecovery() to the CallBatch
These will execute the callbatch against governance, when running in anvil

## PR Checklist

- [ ] Added Tests
- [ ] Updated Documentation
- [x] Updated CHANGELOG.md for the appropriate package
