### PR TITLE
fix: populateRecover sets from for proper gas estimation

### DIFF
--- a/packages/sdk-bridge/CHANGELOG.md
+++ b/packages/sdk-bridge/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Unreleased
 
+- fix: set `from` in call overrides in `prepareRecover`
+
 ### 3.0.0-rc.0
 
 - dep: bump configuration to 2.0.0 and resolve type issues

--- a/packages/sdk-bridge/src/BridgeContext.ts
+++ b/packages/sdk-bridge/src/BridgeContext.ts
@@ -510,9 +510,12 @@ export class BridgeContext extends NomadContext {
     // will be undefined
     if (!this.accountant)
       throw new UnreachableError('checked in nftInfo() call');
+    // set from so that estimation will succeed
+    const callOverrides: ethers.CallOverrides = overrides || {};
+    callOverrides.from = nftInfo._holder;
     // check if it will succeed/fail with callStatic
-    await this.accountant.callStatic.recover(id, overrides);
-    return this.accountant.populateTransaction.recover(id, overrides);
+    await this.accountant.callStatic.recover(id, callOverrides);
+    return this.accountant.populateTransaction.recover(id, callOverrides);
   }
 
   /**


### PR DESCRIPTION
## Motivation

Preflighting recover calls will not work if `from` is not set

## Solution

set from in the prepare method

## PR Checklist

- [ ] Added Tests
- [ ] Updated Documentation
- [x] Updated CHANGELOG.md for the appropriate package
