### PR TITLE
fix: properly formatted tokenId

### DIFF
--- a/packages/contracts-bridge/contracts/test/TokenRegistry.t.sol
+++ b/packages/contracts-bridge/contracts/test/TokenRegistry.t.sol
@@ -128,7 +128,7 @@ contract TokenRegistryTest is BridgeTest {
         public
     {
         vm.assume(domain != 0 && id != bytes32(0));
-        bytes32 tokenId = BridgeMessage.formatTokenId(domain, id);
+        bytes32 tokenId = BridgeMessage.formatTokenId(domain, id).index(0, 32);
         vm.startPrank(tokenRegistry.owner());
         if (domain == localDomain) {
             assertEq(

--- a/packages/contracts-bridge/contracts/test/TokenRegistry.t.sol
+++ b/packages/contracts-bridge/contracts/test/TokenRegistry.t.sol
@@ -127,13 +127,12 @@ contract TokenRegistryTest is BridgeTest {
     function test_ensureLocalTokenDeployFuzzed(uint32 domain, bytes32 id)
         public
     {
-        vm.assume(domain != 0 && id != bytes32(0));
-        bytes32 tokenId = BridgeMessage.formatTokenId(domain, id).index(0, 32);
+        vm.assume(domain != 0 && TypeCasts.bytes32ToAddress(id) != address(0));
         vm.startPrank(tokenRegistry.owner());
         if (domain == localDomain) {
             assertEq(
-                tokenRegistry.ensureLocalToken(domain, tokenId),
-                TypeCasts.bytes32ToAddress(tokenId)
+                tokenRegistry.ensureLocalToken(domain, id),
+                TypeCasts.bytes32ToAddress(id)
             );
             return;
         }

--- a/packages/contracts-bridge/contracts/test/TokenRegistry.t.sol
+++ b/packages/contracts-bridge/contracts/test/TokenRegistry.t.sol
@@ -128,11 +128,12 @@ contract TokenRegistryTest is BridgeTest {
         public
     {
         vm.assume(domain != 0 && id != bytes32(0));
+        bytes32 tokenId = BridgeMessage.formatTokenId(domain, id);
         vm.startPrank(tokenRegistry.owner());
         if (domain == localDomain) {
             assertEq(
-                tokenRegistry.ensureLocalToken(domain, id),
-                TypeCasts.bytes32ToAddress(id)
+                tokenRegistry.ensureLocalToken(domain, tokenId),
+                TypeCasts.bytes32ToAddress(tokenId)
             );
             return;
         }


### PR DESCRIPTION
## Motivation
(from slack, by James)
- the input has domain == localDomain
- the input id has non-empty top bytes, so it passes the vm.assume
- the input id has empty bottom 20 bytes, so getLocalAddress shows the local address as 0
- this triggers the if block in ensureLocalToken, and deploys a new registry token
- ensureLocalToken returns the new token, which is not equal to the lower 20 bytes of the input
this is a condition of use violation. The token registry assumes that there is no local token at address(0), and therefore, the code assumes that it’ll never get a local token ID with empty bottom 20 bytes

## Solution

Ensure in the test that the ID is formatted correctly, which means that the lower 20 bytes should be != 0