### PR TITLE
chore: skip flaky sdk unit tests, add note to fix later

### DIFF
--- a/packages/sdk/tests/index.test.ts
+++ b/packages/sdk/tests/index.test.ts
@@ -7,14 +7,18 @@ const domainA = 1001;
 const domainB = 1002;
 
 describe('NomadContext', () => {
-  it('fetches from hosted configs', async () => {
+  // TODO: figure out a better unit test this
+  // we should not fetch from a hosted url in our unit tests
+  it.skip('fetches from hosted configs', async () => {
     for (const env of ENVIRONMENTS) {
       const context = await NomadContext.fetch(env, false);
       expect(context).toBeDefined();
     }
   });
 
-  it('Is properly instantiated from a NomadConfig', async () => {
+  // TODO: figure out a better unit test this
+  // we should not fetch from a hosted url in our unit tests
+  it.skip('Is properly instantiated from a NomadConfig', async () => {
     for (const env of ENVIRONMENTS) {
       const conf = await NomadContext.fetchConfig(env);
       const context = new NomadContext(conf);


### PR DESCRIPTION
## Motivation

These 2 sdk unit tests would fail occasionally due to a timeout since it fetches from a hosted url

## Solution

Skip these for now and add a note to fix in the future.

## PR Checklist

- [ ] Added Tests
- [ ] Updated Documentation
- [ ] Updated CHANGELOG.md for the appropriate package
