### PR TITLE
fix: override updater properly in reboot setup

### DIFF
--- a/packages/contracts-ops/contracts/Config.sol
+++ b/packages/contracts-ops/contracts/Config.sol
@@ -424,7 +424,7 @@ abstract contract Config is INomadProtocol {
     function protocolConfigAttributePath(
         string memory domain,
         string memory key
-    ) private pure returns (string memory) {
+    ) internal pure returns (string memory) {
         return string(abi.encodePacked(protocolConfigPath(domain), ".", key));
     }
 

--- a/packages/contracts-ops/contracts/test/Reboot.t.sol
+++ b/packages/contracts-ops/contracts/test/Reboot.t.sol
@@ -28,12 +28,21 @@ contract RebootTest is RebootLogic, NomadTest {
         __CallBatch_initialize(_domain, getDomainNumber(_domain), "", true);
         // call base setup
         super.setUp();
-        // set fake updater for ethereum & 1 remote chain
+        // basic vars
+        remote = getConnections(localDomainName)[0];
+        remoteDomain = getDomainNumber(remote);
+        homeDomain = getDomainNumber(localDomainName);
+        // set fake updater for remote chain replica
         // before updater rotation, so it will be rotated on-chain
         vm.writeJson(
             vm.toString(updaterAddr),
             outputPath,
-            protocolAttributePath(remote, "updater")
+            protocolConfigAttributePath(localDomainName, "updater")
+        );
+        vm.writeJson(
+            vm.toString(updaterAddr),
+            outputPath,
+            protocolConfigAttributePath(remote, "updater")
         );
         reloadConfig();
         // perform reboot actions
@@ -43,9 +52,5 @@ contract RebootTest is RebootLogic, NomadTest {
             address(getGovernanceRouter(localDomainName)),
             getDomainNumber(localDomainName)
         );
-        // basic vars
-        remote = getConnections(localDomainName)[0];
-        remoteDomain = getDomainNumber(remote);
-        homeDomain = getDomainNumber(localDomainName);
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below. Bug fixes and new features should include tests.

New contributors should read the contributors guide:
https://github.com/nomad-xyz/monorepo/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building
the documentation.
-->

## Motivation
- Fork tests intended to change two specific Updaters (Home and one Replica) in order to facilitate local signing of Updates
- Home updater was not being set anywhere, while Replica updater setting had a bug (`remote` variable was empty)
- however, Due to unexpected behavior in `vm.writeJson`, all updaters in the config were being overwritten - which caused the tests to pass anyway 
- this is not the expected or desired state

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Fix the setup
- ensure `remote` is set first
- set only the two specific desired updaters

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Updated Documentation
- [ ] Updated CHANGELOG.md for the appropriate package
