### PR TITLE
fix: governance tests work for governor and non-governor chains

### DIFF
--- a/packages/contracts-core/contracts/test/GovernanceRouter.t.sol
+++ b/packages/contracts-core/contracts/test/GovernanceRouter.t.sol
@@ -853,7 +853,7 @@ contract GovernanceRouterTest is NomadTest {
         // todo: expectNoCall Home.Dispatch
         vm.expectEmit(true, true, true, true);
         emit TransferGovernor(
-            homeDomain,
+            governanceRouter.governorDomain(),
             newDomain,
             governanceRouter.governor(),
             newGovernor
@@ -889,7 +889,7 @@ contract GovernanceRouterTest is NomadTest {
         // todo: expectNoCall Home.Dispatch
         vm.expectEmit(true, true, true, true);
         emit TransferGovernor(
-            homeDomain,
+            governanceRouter.governorDomain(),
             newDomain,
             governanceRouter.governor(),
             newGovernor

--- a/packages/contracts-ops/contracts/test/Reboot.t.sol
+++ b/packages/contracts-ops/contracts/test/Reboot.t.sol
@@ -29,7 +29,15 @@ contract RebootTest is RebootLogic, NomadTest {
         // call base setup
         super.setUp();
         // basic vars
-        remote = getConnections(localDomainName)[0];
+        string memory governorDomainName = getDomainName(getGovernorDomain());
+        if (
+            keccak256(bytes(localDomainName)) ==
+            keccak256(bytes(governorDomainName))
+        ) {
+            remote = getConnections(localDomainName)[0];
+        } else {
+            remote = governorDomainName;
+        }
         remoteDomain = getDomainNumber(remote);
         homeDomain = getDomainNumber(localDomainName);
         // set fake updater for remote chain replica


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below. Bug fixes and new features should include tests.

New contributors should read the contributors guide:
https://github.com/nomad-xyz/monorepo/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building
the documentation.
-->

## Motivation
If we run fork tests on other chains, the governance router tests need to function for both the governor domain and the non-governor domain
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
for non-governor domains,
- for `handle` tests, ensure the remote domain is `setUp` to the governor domain. the GovernanceRouter tests assume that the remoteDomain is the governor domain; on the actual governor domain, the tests just transfer to the remote domain; but for non-governor domains, this is not possible
- for `TransferGovernor` tests, don't assume homeDomain is the current governor domain. 
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Updated Documentation
- [ ] Updated CHANGELOG.md for the appropriate package
