### PR TITLE
update: deprecate staging

### DIFF
--- a/packages/sdk-bridge/CHANGELOG.md
+++ b/packages/sdk-bridge/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Unreleased
 
-### 3.0.0-rc.1
+### 3.0.1-rc.0
 
 - fix: remove staging env and references to staging
 - fix: set `from` in call overrides in `prepareRecover`

--- a/packages/sdk-bridge/CHANGELOG.md
+++ b/packages/sdk-bridge/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Unreleased
 
-### 3.0.1-rc.0
+### 3.1.0-rc.0
 
 - fix: remove staging env and references to staging
 - fix: set `from` in call overrides in `prepareRecover`

--- a/packages/sdk-bridge/CHANGELOG.md
+++ b/packages/sdk-bridge/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### Unreleased
 
+### 3.0.0-rc.1
+
+- fix: remove staging env and references to staging
 - fix: set `from` in call overrides in `prepareRecover`
 
 ### 3.0.0-rc.0

--- a/packages/sdk-bridge/README.md
+++ b/packages/sdk-bridge/README.md
@@ -44,9 +44,8 @@ Instantiate a [BridgeContext](https://docs.nomad.xyz/sdk-bridge/classes/bridgeco
 // sdk includes a wasm module, so must await the import
 const { BridgeContext } = await import('@nomad-xyz/sdk-bridge')
 
-type Env = 'production' | 'staging' | 'development'
-// staging is the recommended testnet environment
-const environment: Env = 'staging'
+type Env = 'production' | 'development'
+const environment: Env = 'development'
 // instantiate a preconfigured BridgeContext
 const bridgeContext = await BridgeContext.fetch(environment)
 ```

--- a/packages/sdk-bridge/package.json
+++ b/packages/sdk-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nomad-xyz/sdk-bridge",
-  "version": "3.0.1-rc.0",
+  "version": "3.1.0-rc.0",
   "description": "Nomad bridge SDK",
   "keywords": [
     "nomad",

--- a/packages/sdk-bridge/package.json
+++ b/packages/sdk-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nomad-xyz/sdk-bridge",
-  "version": "3.0.0-rc.0",
+  "version": "3.0.1-rc.0",
   "description": "Nomad bridge SDK",
   "keywords": [
     "nomad",

--- a/packages/sdk-bridge/src/BridgeContext.ts
+++ b/packages/sdk-bridge/src/BridgeContext.ts
@@ -472,11 +472,11 @@ export class BridgeContext extends NomadContext {
 
   /**
    * Get the accountant associated with this environment, if any. Accountants
-   * will be on Goerli for staging, Ethereum for production.
+   * will be on Goerli for development, Ethereum for production.
    */
   get accountant(): bridge.NFTAccountant | undefined {
     switch (this.environment) {
-      case 'staging': {
+      case 'development': {
         return bridge.NftAccountant__factory.connect(
           MOCK_GOERLI_ACCOUNTANT,
           this.mustGetConnection('goerli'),

--- a/packages/sdk-bridge/tests/index.test.ts
+++ b/packages/sdk-bridge/tests/index.test.ts
@@ -3,7 +3,7 @@ import * as config from '@nomad-xyz/configuration';
 
 import { NomadContext } from '@nomad-xyz/sdk';
 
-const ENVIRONMENTS = ['development', 'staging', 'production'];
+const ENVIRONMENTS = ['development', 'production'];
 
 describe('sdk-bridge', () => {
   describe('BridgeContext', () => {

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### Unreleased
 
+### 3.1.0-rc.0
+
+- remove staging
+
 ### 3.0.0-rc.0
 
 - dep: bump configuration to 2.0.0 and resolve type issues

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nomad-xyz/sdk",
-  "version": "3.0.0-rc.0",
+  "version": "3.1.0-rc.0",
   "description": "Nomad SDK",
   "keywords": [
     "nomad",


### PR DESCRIPTION
Deprecate staging

## Motivation

We shouldn't reference staging or support staging anywhere in sdk. Wasn't able to access testnet MockAccountant from development.

## Solution

Replace references to staging with development, remove staging from choices of env.

## PR Checklist

- [ ] Added Tests
- [x] Updated Documentation
- [x] Updated CHANGELOG.md for the appropriate package
