### PR TITLE
fix: release sdk first

### DIFF
--- a/packages/sdk-bridge/CHANGELOG.md
+++ b/packages/sdk-bridge/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### Unreleased
 
+### 3.1.0-rc.3
+
+- fix: release sdk package first
+
 ### 3.1.0-rc.0
 
 - fix: remove staging env and references to staging

--- a/packages/sdk-bridge/package.json
+++ b/packages/sdk-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nomad-xyz/sdk-bridge",
-  "version": "3.1.0-rc.0",
+  "version": "3.1.0-rc.3",
   "description": "Nomad bridge SDK",
   "keywords": [
     "nomad",

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### Unreleased
 
+### 3.1.0-rc.3
+
+- fix: release sdk package first
+
 ### 3.1.0-rc.0
 
 - remove staging

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nomad-xyz/sdk",
-  "version": "3.1.0-rc.0",
+  "version": "3.1.0-rc.3",
   "description": "Nomad SDK",
   "keywords": [
     "nomad",


### PR DESCRIPTION
Bump sdk and sdk-bridge packages

## Motivation

sdk wasn't built before release causing errors in sdk-bridge

## Solution

Bump and release both packages

## PR Checklist

- [ ] Added Tests
- [ ] Updated Documentation
- [x] Updated CHANGELOG.md for the appropriate package
