### PR TITLE
add: get BridgeMessage from MessageHash

### DIFF
--- a/packages/sdk-bridge/CHANGELOG.md
+++ b/packages/sdk-bridge/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### Unreleased
 
+### 3.2.0-rc.0
+
+- feat: instantiate from message hash
+
 ### 3.1.0-rc.3
 
 - fix: release sdk package first

--- a/packages/sdk-bridge/package.json
+++ b/packages/sdk-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nomad-xyz/sdk-bridge",
-  "version": "3.2.0-rc.0",
+  "version": "3.2.0-rc.2",
   "description": "Nomad bridge SDK",
   "keywords": [
     "nomad",

--- a/packages/sdk-bridge/package.json
+++ b/packages/sdk-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nomad-xyz/sdk-bridge",
-  "version": "3.1.0-rc.3",
+  "version": "3.2.0-rc.0",
   "description": "Nomad bridge SDK",
   "keywords": [
     "nomad",

--- a/packages/sdk-bridge/src/BridgeMessage.ts
+++ b/packages/sdk-bridge/src/BridgeMessage.ts
@@ -122,17 +122,18 @@ export class BridgeMessage extends NomadMessage<BridgeContext> {
   static async bridgeFirstFromBackend(
     context: BridgeContext,
     transactionHash: string,
-    // _backend?: BridgeMessageBackend,
   ): Promise<BridgeMessage> {
-    // const backend = context._backend || _backend;
-    // if (!backend) {
-    //   throw new Error(`No backend is set for the context`);
-    // }
-    // const dispatches = await backend.getDispatches(transactionHash, 1);
-    // if (!dispatches || dispatches.length === 0) throw new Error(`No dispatch`);
-
-    // const m = new NomadMessage(context, dispatches[0]);
     const m = await this.baseFirstFromBackend(context, transactionHash);
+    const bm = BridgeMessage.fromNomadMessage(context, m, context._backend);
+
+    return bm;
+  }
+
+  static async bridgeFromMessageHash(
+    context: BridgeContext,
+    messageHash: string,
+  ): Promise<BridgeMessage> {
+    const m = await this.baseFromMessageHash(context, messageHash);
     const bm = BridgeMessage.fromNomadMessage(context, m, context._backend);
 
     return bm;

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### Unreleased
 
+### 3.2.0-rc.0
+
+- feat: instantiate from message hash
+
 ### 3.1.0-rc.3
 
 - fix: release sdk package first

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nomad-xyz/sdk",
-  "version": "3.1.0-rc.3",
+  "version": "3.2.0-rc.0",
   "description": "Nomad SDK",
   "keywords": [
     "nomad",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nomad-xyz/sdk",
-  "version": "3.2.0-rc.0",
+  "version": "3.2.0-rc.2",
   "description": "Nomad SDK",
   "keywords": [
     "nomad",

--- a/packages/sdk/src/messageBackend/backend.ts
+++ b/packages/sdk/src/messageBackend/backend.ts
@@ -11,6 +11,7 @@ export abstract class MessageBackend {
     limit?: number,
   ): Promise<Dispatch[] | undefined>;
   abstract getFirstMessageHash(tx: string): Promise<string | undefined>;
+  abstract getDispatchByMessageHash(messageHash: string): Promise<Dispatch | undefined>;
 
   abstract dispatchTx(messageHash: string): Promise<string | undefined>;
   abstract updateTx(messageHash: string): Promise<string | undefined>;

--- a/packages/sdk/src/messageBackend/goldsky.ts
+++ b/packages/sdk/src/messageBackend/goldsky.ts
@@ -203,6 +203,29 @@ export class GoldSkyBackend extends MessageBackend {
   }
 
   /**
+   * Prepares a Dispatch event from backend's internal message representation
+   *
+   * @returns Dispatch event assiciated with message hash (if any)
+   */
+  async getDispatchByMessageHash(
+    messageHash: string,
+  ): Promise<Dispatch | undefined> {
+    const ms = await this.getMessage(messageHash)
+    if (!ms) return
+
+    return ({
+      args: {
+        messageHash: ms?.message_hash,
+        leafIndex: BigNumber.from(ms.leaf_index),
+        destinationAndNonce: BigNumber.from(ms.destination_and_nonce),
+        committedRoot: ms.committed_root,
+        message: ms.message,
+      },
+      transactionHash: ms.dispatch_tx,
+    })
+  }
+
+  /**
    * Stores message into internal cache
    */
   storeMessage(m: GoldSkyMessage): void {

--- a/packages/sdk/src/messageBackend/goldsky.ts
+++ b/packages/sdk/src/messageBackend/goldsky.ts
@@ -210,8 +210,8 @@ export class GoldSkyBackend extends MessageBackend {
   async getDispatchByMessageHash(
     messageHash: string,
   ): Promise<Dispatch | undefined> {
-    const ms = await this.getMessage(messageHash)
-    if (!ms) return
+    const ms = await this.getMessage(messageHash);
+    if (!ms) return;
 
     return ({
       args: {
@@ -222,7 +222,7 @@ export class GoldSkyBackend extends MessageBackend {
         message: ms.message,
       },
       transactionHash: ms.dispatch_tx,
-    })
+    });
   }
 
   /**

--- a/packages/sdk/src/messages/NomadMessage.ts
+++ b/packages/sdk/src/messages/NomadMessage.ts
@@ -208,6 +208,21 @@ export class NomadMessage<T extends NomadContext> {
     return m;
   }
 
+  static async baseFromMessageHash<T extends NomadContext>(
+    context: T,
+    messageHash: string,
+  ): Promise<NomadMessage<T>> {
+    if (!context._backend) {
+      throw new Error(`No backend is set for the context`);
+    }
+    const dispatch = await context._backend.getDispatchByMessageHash(messageHash);
+    if (!dispatch) throw new Error(`No dispatch`);
+
+    const m = new NomadMessage(context, dispatch);
+
+    return m;
+  }
+
   /**
    * Get the `Relay` event associated with this message (if any)
    *


### PR DESCRIPTION
## Motivation

Would like to get BridgeMessage from MessageHash as that is more precise and less prone to error

## Solution

Add `baseFromMessageHash` and `bridgeFromMessageHash` methods

## PR Checklist

- [ ] Added Tests
- [x] Updated Documentation
- [x] Updated CHANGELOG.md for the appropriate package
