### PR TITLE
Fix typos

### DIFF
--- a/packages/contracts-da-bridge/contracts/DABridgeRouter.sol
+++ b/packages/contracts-da-bridge/contracts/DABridgeRouter.sol
@@ -60,7 +60,7 @@ contract DABridgeRouter is Version0, Router {
     /**
      * @notice Receive messages sent via Nomad from other remote xApp Routers;
      * parse the contents of the message and enact the message's effects on the local chain
-     * @dev Called by an Nomad Replica contract while processing a message sent via Nomad
+     * @dev Called by a Nomad Replica contract while processing a message sent via Nomad
      * @param _origin The domain the message is coming from
      * @param _nonce The unique identifier for the message from origin to destination
      * @param _sender The address the message is coming from

--- a/packages/contracts-router/contracts/XAppConnectionClient.sol
+++ b/packages/contracts-router/contracts/XAppConnectionClient.sol
@@ -15,7 +15,7 @@ abstract contract XAppConnectionClient is OwnableUpgradeable {
     // ============ Modifiers ============
 
     /**
-     * @notice Only accept messages from an Nomad Replica contract
+     * @notice Only accept messages from a Nomad Replica contract
      */
     modifier onlyReplica() {
         require(_isReplica(msg.sender), "!replica");

--- a/packages/multi-provider/src/utils.ts
+++ b/packages/multi-provider/src/utils.ts
@@ -77,7 +77,7 @@ export function canonizeId(data: BytesLike): Uint8Array {
 }
 
 /**
- * Converts an Nomad ID of 20 or 32 bytes to the corresponding EVM Address.
+ * Converts a Nomad ID of 20 or 32 bytes to the corresponding EVM Address.
  *
  * For 32-byte IDs this enforces the EVM convention of using the LAST 20 bytes.
  *


### PR DESCRIPTION
This pull request addresses typos in the following files:
- **DABridgeRouter.sol**: Corrected an instance of "an Nomad" to "a Nomad" for grammatical accuracy.
- **XAppConnectionClient.sol**: Fixed "an Nomad Replica contract" to "a Nomad Replica contract."
- **utils.ts**: Updated "an Nomad ID" to "a Nomad ID" in the comment for consistency.

These changes improve the clarity and correctness of the code documentation.
